### PR TITLE
32 Move root.html.erb to index.html.erb

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -1,8 +1,3 @@
-// Support component names relative to this directory:
-// Run this example by adding <%= javascript_pack_tag 'hello_react' %> to the head of your layout file,
-// like app/views/layouts/application.html.erb. All it does is render <div>Hello React</div> at the bottom
-// of the page.
-
 import "../css/application.css";
 
 import React from "react";

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -1,0 +1,2 @@
+<div id="root">
+</div>

--- a/app/views/pages/root.html.erb
+++ b/app/views/pages/root.html.erb
@@ -1,2 +1,0 @@
-<div id="root" >
-</div>


### PR DESCRIPTION
## Background
In it's current state, running `master` fails to render the `GET /` route as there is no template given. This can be fixed by renaming `app/views/pages/root.html.erb` to `app/views/pages/index.html.erb`

## Definition of Done
 
- [x] Replace `app/views/pages/root.html.erb` with `app/views/pages/index.html.erb`
- [x] Running the application and navigating to `http://localhost:3000` renders the `Hello` component
