### PR TITLE
Removes the all_* prefix for the collection queries

### DIFF
--- a/app/graphql/queries/github_users/github_users_query.rb
+++ b/app/graphql/queries/github_users/github_users_query.rb
@@ -4,7 +4,7 @@ module Queries
   module GithubUsers
     # Query class that fetches all GithubUsers in the db
     #
-    class AllGithubUsersQuery < Queries::BaseQuery
+    class GithubUsersQuery < Queries::BaseQuery
       description 'All Github Users.'
 
       type [Types::GithubUserType], null: false

--- a/app/graphql/queries/github_users/query_manifest.rb
+++ b/app/graphql/queries/github_users/query_manifest.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative 'all_github_users_query'
+require_relative 'github_users_query'
 require_relative 'github_user_query'
 
 module Queries
@@ -14,8 +14,8 @@ module Queries
       extend ActiveSupport::Concern
 
       included do
-        field :all_github_users, resolver: Queries::GithubUsers::AllGithubUsersQuery
         field :github_user, resolver: Queries::GithubUsers::GithubUserQuery
+        field :github_users, resolver: Queries::GithubUsers::GithubUsersQuery
       end
     end
   end

--- a/app/graphql/queries/organizations/organizations_query.rb
+++ b/app/graphql/queries/organizations/organizations_query.rb
@@ -4,7 +4,7 @@ module Queries
   module Organizations
     # Query class that fetches all Organizations in the db
     #
-    class AllOrganizationsQuery < Queries::BaseQuery
+    class OrganizationsQuery < Queries::BaseQuery
       description 'All organizations.'
 
       type [Types::OrganizationType], null: false

--- a/app/graphql/queries/organizations/query_manifest.rb
+++ b/app/graphql/queries/organizations/query_manifest.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative 'all_organizations_query'
+require_relative 'organizations_query'
 require_relative 'organization_query'
 
 module Queries
@@ -13,8 +13,8 @@ module Queries
       extend ActiveSupport::Concern
 
       included do
-        field :all_organizations, resolver: Queries::Organizations::AllOrganizationsQuery
         field :organization, resolver: Queries::Organizations::OrganizationQuery
+        field :organizations, resolver: Queries::Organizations::OrganizationsQuery
       end
     end
   end

--- a/app/graphql/queries/repositories/query_manifest.rb
+++ b/app/graphql/queries/repositories/query_manifest.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative 'all_repositories_query'
+require_relative 'repositories_query'
 require_relative 'repository_query'
 
 module Queries
@@ -14,7 +14,7 @@ module Queries
       extend ActiveSupport::Concern
 
       included do
-        field :all_repositories, resolver: Queries::Repositories::AllRepositoriesQuery
+        field :repositories, resolver: Queries::Repositories::RepositoriesQuery
         field :repository, resolver: Queries::Repositories::RepositoryQuery
       end
     end

--- a/app/graphql/queries/repositories/repositories_query.rb
+++ b/app/graphql/queries/repositories/repositories_query.rb
@@ -4,7 +4,7 @@ module Queries
   module Repositories
     # Query class that fetches all Repositories in the db
     #
-    class AllRepositoriesQuery < Queries::BaseQuery
+    class RepositoriesQuery < Queries::BaseQuery
       description 'All repositories.'
 
       type [Types::RepositoryType], null: false

--- a/app/graphql/queries/statistics/query_manifest.rb
+++ b/app/graphql/queries/statistics/query_manifest.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative 'all_statistics_query'
+require_relative 'statistics_query'
 require_relative 'statistic_query'
 
 module Queries
@@ -14,8 +14,8 @@ module Queries
       extend ActiveSupport::Concern
 
       included do
-        field :all_statistics, resolver: Queries::Statistics::AllStatisticsQuery
         field :statistic, resolver: Queries::Statistics::StatisticQuery
+        field :statistics, resolver: Queries::Statistics::StatisticsQuery
       end
     end
   end

--- a/app/graphql/queries/statistics/statistics_query.rb
+++ b/app/graphql/queries/statistics/statistics_query.rb
@@ -4,7 +4,7 @@ module Queries
   module Statistics
     # Query class that fetches all Statistics in the db
     #
-    class AllStatisticsQuery < Queries::BaseQuery
+    class StatisticsQuery < Queries::BaseQuery
       description 'All statistics.'
 
       type [Types::StatisticType], null: false

--- a/app/graphql/queries/users/query_manifest.rb
+++ b/app/graphql/queries/users/query_manifest.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative 'all_users_query'
+require_relative 'users_query'
 require_relative 'user_query'
 
 module Queries
@@ -14,8 +14,8 @@ module Queries
       extend ActiveSupport::Concern
 
       included do
-        field :all_users, resolver: Queries::Users::AllUsersQuery
         field :user, resolver: Queries::Users::UserQuery
+        field :users, resolver: Queries::Users::UsersQuery
       end
     end
   end

--- a/app/graphql/queries/users/users_query.rb
+++ b/app/graphql/queries/users/users_query.rb
@@ -4,7 +4,7 @@ module Queries
   module Users
     # Query class that fetches all Users in the db
     #
-    class AllUsersQuery < Queries::BaseQuery
+    class UsersQuery < Queries::BaseQuery
       description 'All Users.'
 
       type [Types::UserType], null: false

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -56,26 +56,20 @@ type RootMutation {
 }
 
 type RootQuery {
-  # All Github Users.
-  allGithubUsers(limit: Int): [GithubUser!]!
-
-  # All organizations.
-  allOrganizations(limit: Int): [Organization!]!
-
-  # All repositories.
-  allRepositories(limit: Int): [Repository!]!
-
-  # All statistics.
-  allStatistics(limit: Int): [Statistic!]!
-
-  # All Users.
-  allUsers(limit: Int): [User!]!
-
   # The Github User with the passed criteria.
   githubUser(githubLogin: String, id: ID): GithubUser!
 
+  # All Github Users.
+  githubUsers(limit: Int): [GithubUser!]!
+
   # The organization with the passed criteria.
   organization(id: ID, name: String): Organization!
+
+  # All organizations.
+  organizations(limit: Int): [Organization!]!
+
+  # All repositories.
+  repositories(limit: Int): [Repository!]!
 
   # The repository with the passed criteria.
   repository(id: ID, name: String): Repository!
@@ -83,8 +77,14 @@ type RootQuery {
   # The statistic with the passed criteria.
   statistic(id: ID, sourceId: String): Statistic!
 
+  # All statistics.
+  statistics(limit: Int): [Statistic!]!
+
   # The User with the passed criteria.
   user(githubUsername: String, id: ID): User!
+
+  # All Users.
+  users(limit: Int): [User!]!
 }
 
 type Statistic {

--- a/lib/tasks/graphql.rake
+++ b/lib/tasks/graphql.rake
@@ -1,9 +1,11 @@
-task dump_schema: :environment do
-  # Get a string containing the definition in GraphQL IDL:
-  schema_defn = MagnifierSchema.to_definition
-  # Choose a place to write the schema dump:
-  schema_path = "app/graphql/schema.graphql"
-  # Write the schema dump to that file:
-  File.write(Rails.root.join(schema_path), schema_defn)
-  puts "Updated #{schema_path}"
+namespace :graphql do
+  task dump_schema: :environment do
+    # Get a string containing the definition in GraphQL IDL:
+    schema_defn = MagnifierSchema.to_definition
+    # Choose a place to write the schema dump:
+    schema_path = "app/graphql/schema.graphql"
+    # Write the schema dump to that file:
+    File.write(Rails.root.join(schema_path), schema_defn)
+    puts "Updated #{schema_path}"
+  end
 end

--- a/spec/graphql/queries/github_users/github_users_query_spec.rb
+++ b/spec/graphql/queries/github_users/github_users_query_spec.rb
@@ -2,38 +2,36 @@
 
 require 'rails_helper'
 
-RSpec.describe Queries::Users::AllUsersQuery do
-  before { 6.times { create :user } }
+RSpec.describe Queries::GithubUsers::GithubUsersQuery do
+  before { 6.times { create :github_user } }
 
   context 'with no arguments' do
     let(:query) do
       <<-GRAPHQL
         query {
-          allUsers {
-            firstName
-            lastName
-            email
-            githubUsername
+          githubUsers {
+            githubLogin
             id
+            userId
+            githubId
           }
         }
       GRAPHQL
     end
     let(:response) { MagnifierSchema.execute(query, context: {}) }
-    let(:results) { response.dig('data', 'allUsers') }
+    let(:results) { response.dig('data', 'githubUsers') }
 
-    it 'returns all Users in the db' do
+    it 'returns all Github Users in the db' do
       expect(results.size).to eq(6)
     end
 
     it 'returns the requested db attributes' do
       expect(results.first.keys).to match(
         %w[
-          firstName
-          lastName
-          email
-          githubUsername
+          githubLogin
           id
+          userId
+          githubId
         ]
       )
     end
@@ -43,12 +41,11 @@ RSpec.describe Queries::Users::AllUsersQuery do
     let(:limited_query) do
       <<-GRAPHQL
         query {
-          allUsers(limit: 3) {
-            firstName
-            lastName
-            email
-            githubUsername
+          githubUsers(limit: 3) {
+            githubLogin
             id
+            userId
+            githubId
           }
         }
       GRAPHQL
@@ -56,7 +53,7 @@ RSpec.describe Queries::Users::AllUsersQuery do
 
     it 'limits the response items to the requested limit' do
       response = MagnifierSchema.execute limited_query, context: {}
-      results  = response.dig('data', 'allUsers')
+      results  = response.dig('data', 'githubUsers')
 
       expect(results.size).to eq(3)
     end

--- a/spec/graphql/queries/organizations/organizations_query_spec.rb
+++ b/spec/graphql/queries/organizations/organizations_query_spec.rb
@@ -2,36 +2,36 @@
 
 require 'rails_helper'
 
-RSpec.describe Queries::GithubUsers::AllGithubUsersQuery do
-  before { 6.times { create :github_user } }
+RSpec.describe Queries::Organizations::OrganizationsQuery do
+  before { 6.times { create :organization } }
 
   context 'with no arguments' do
     let(:query) do
       <<-GRAPHQL
         query {
-          allGithubUsers {
-            githubLogin
-            id
-            userId
-            githubId
+          organizations {
+            url
+            name
+            createdAt
+            updatedAt
           }
         }
       GRAPHQL
     end
     let(:response) { MagnifierSchema.execute(query, context: {}) }
-    let(:results) { response.dig('data', 'allGithubUsers') }
+    let(:results) { response.dig('data', 'organizations') }
 
-    it 'returns all Github Users in the db' do
+    it 'returns all organizations in the db' do
       expect(results.size).to eq(6)
     end
 
     it 'returns the requested db attributes' do
       expect(results.first.keys).to match(
         %w[
-          githubLogin
-          id
-          userId
-          githubId
+          url
+          name
+          createdAt
+          updatedAt
         ]
       )
     end
@@ -41,11 +41,9 @@ RSpec.describe Queries::GithubUsers::AllGithubUsersQuery do
     let(:limited_query) do
       <<-GRAPHQL
         query {
-          allGithubUsers(limit: 3) {
-            githubLogin
-            id
-            userId
-            githubId
+          organizations(limit: 3) {
+            url
+            name
           }
         }
       GRAPHQL
@@ -53,7 +51,7 @@ RSpec.describe Queries::GithubUsers::AllGithubUsersQuery do
 
     it 'limits the response items to the requested limit' do
       response = MagnifierSchema.execute limited_query, context: {}
-      results  = response.dig('data', 'allGithubUsers')
+      results  = response.dig('data', 'organizations')
 
       expect(results.size).to eq(3)
     end

--- a/spec/graphql/queries/repositories/repositories_query_spec.rb
+++ b/spec/graphql/queries/repositories/repositories_query_spec.rb
@@ -2,36 +2,32 @@
 
 require 'rails_helper'
 
-RSpec.describe Queries::Organizations::AllOrganizationsQuery do
-  before { 6.times { create :organization } }
+RSpec.describe Queries::Repositories::RepositoriesQuery do
+  before { 6.times { create :repository } }
 
   context 'with no arguments' do
     let(:query) do
       <<-GRAPHQL
         query {
-          allOrganizations {
-            url
+          repositories {
             name
-            createdAt
-            updatedAt
+            url
           }
         }
       GRAPHQL
     end
     let(:response) { MagnifierSchema.execute(query, context: {}) }
-    let(:results) { response.dig('data', 'allOrganizations') }
+    let(:results) { response.dig('data', 'repositories') }
 
-    it 'returns all organizations in the db' do
+    it 'returns all Repositories in the db' do
       expect(results.size).to eq(6)
     end
 
     it 'returns the requested db attributes' do
       expect(results.first.keys).to match(
         %w[
-          url
           name
-          createdAt
-          updatedAt
+          url
         ]
       )
     end
@@ -41,9 +37,9 @@ RSpec.describe Queries::Organizations::AllOrganizationsQuery do
     let(:limited_query) do
       <<-GRAPHQL
         query {
-          allOrganizations(limit: 3) {
-            url
+          repositories(limit: 3) {
             name
+            url
           }
         }
       GRAPHQL
@@ -51,7 +47,7 @@ RSpec.describe Queries::Organizations::AllOrganizationsQuery do
 
     it 'limits the response items to the requested limit' do
       response = MagnifierSchema.execute limited_query, context: {}
-      results  = response.dig('data', 'allOrganizations')
+      results  = response.dig('data', 'repositories')
 
       expect(results.size).to eq(3)
     end

--- a/spec/graphql/queries/statistics/statistics_query_spec.rb
+++ b/spec/graphql/queries/statistics/statistics_query_spec.rb
@@ -2,14 +2,14 @@
 
 require 'rails_helper'
 
-RSpec.describe Queries::Statistics::AllStatisticsQuery do
+RSpec.describe Queries::Statistics::StatisticsQuery do
   before { 6.times { create :statistic } }
 
   context 'with no arguments' do
     let(:query) do
       <<-GRAPHQL
         query {
-          allStatistics {
+          statistics {
             source
             sourceId
             sourceType
@@ -23,7 +23,7 @@ RSpec.describe Queries::Statistics::AllStatisticsQuery do
       GRAPHQL
     end
     let(:response) { MagnifierSchema.execute(query, context: {}) }
-    let(:results) { response.dig('data', 'allStatistics') }
+    let(:results) { response.dig('data', 'statistics') }
 
     it 'returns all Statistics in the db' do
       expect(results.size).to eq(6)
@@ -49,7 +49,7 @@ RSpec.describe Queries::Statistics::AllStatisticsQuery do
     let(:limited_query) do
       <<-GRAPHQL
         query {
-          allStatistics(limit: 3) {
+          statistics(limit: 3) {
             source
             sourceId
             sourceType
@@ -65,7 +65,7 @@ RSpec.describe Queries::Statistics::AllStatisticsQuery do
 
     it 'limits the response items to the requested limit' do
       response = MagnifierSchema.execute limited_query, context: {}
-      results  = response.dig('data', 'allStatistics')
+      results  = response.dig('data', 'statistics')
 
       expect(results.size).to eq(3)
     end

--- a/spec/graphql/queries/users/users_query_spec.rb
+++ b/spec/graphql/queries/users/users_query_spec.rb
@@ -2,32 +2,38 @@
 
 require 'rails_helper'
 
-RSpec.describe Queries::Repositories::AllRepositoriesQuery do
-  before { 6.times { create :repository } }
+RSpec.describe Queries::Users::UsersQuery do
+  before { 6.times { create :user } }
 
   context 'with no arguments' do
     let(:query) do
       <<-GRAPHQL
         query {
-          allRepositories {
-            name
-            url
+          users {
+            firstName
+            lastName
+            email
+            githubUsername
+            id
           }
         }
       GRAPHQL
     end
     let(:response) { MagnifierSchema.execute(query, context: {}) }
-    let(:results) { response.dig('data', 'allRepositories') }
+    let(:results) { response.dig('data', 'users') }
 
-    it 'returns all Repositories in the db' do
+    it 'returns all Users in the db' do
       expect(results.size).to eq(6)
     end
 
     it 'returns the requested db attributes' do
       expect(results.first.keys).to match(
         %w[
-          name
-          url
+          firstName
+          lastName
+          email
+          githubUsername
+          id
         ]
       )
     end
@@ -37,9 +43,12 @@ RSpec.describe Queries::Repositories::AllRepositoriesQuery do
     let(:limited_query) do
       <<-GRAPHQL
         query {
-          allRepositories(limit: 3) {
-            name
-            url
+          users(limit: 3) {
+            firstName
+            lastName
+            email
+            githubUsername
+            id
           }
         }
       GRAPHQL
@@ -47,7 +56,7 @@ RSpec.describe Queries::Repositories::AllRepositoriesQuery do
 
     it 'limits the response items to the requested limit' do
       response = MagnifierSchema.execute limited_query, context: {}
-      results  = response.dig('data', 'allRepositories')
+      results  = response.dig('data', 'users')
 
       expect(results.size).to eq(3)
     end


### PR DESCRIPTION
## Background
Favors naming collection queries by pluralizing the model name, without adding an `all_*` prefix.

For example, favors `organizations` over `allOrganizations` as the GraphQL query name for fetching a collection of `Organization` records.
 
## Definition of Done
 
- [x] Removes the all_* prefix for the collection queries 
- [x] Namespaces the GraphQL rake tasks