### PR TITLE
Smartly persist issue and PR data fetched from GitHub to the appropriate db tables

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -62,3 +62,12 @@ Style/StderrPuts:
 Metrics/MethodLength:
   Exclude:
     - app/controllers/graphql_controller.rb
+    - spec/**/*
+
+Style/Documentation:
+  Enabled: false
+
+Metrics/AbcSize:
+  Exclude:
+    - app/controllers/graphql_controller.rb
+    - spec/**/*

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem 'coffee-rails', '~> 4.2'
 gem 'graphql', '~> 1.8', '>= 1.8.10'
 gem 'httparty', '~> 0.16.2'
 gem 'jbuilder', '~> 2.5'
+gem 'omniauth-google-oauth2'
 gem 'pg', '>= 0.18', '< 2.0'
 gem 'puma', '~> 3.11'
 gem 'sass-rails', '~> 5.0'
@@ -19,7 +20,6 @@ gem 'turbolinks', '~> 5'
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
 gem 'uglifier', '>= 1.3.0'
 gem 'webpacker', '>= 4.0.x'
-gem "omniauth-google-oauth2"
 
 group :development, :test do
   gem 'awesome_print', '~> 1.8'
@@ -38,8 +38,8 @@ group :development do
   gem 'spring-commands-rspec', '~> 1.0', '>= 1.0.4'
   gem 'spring-watcher-listen', '~> 2.0.0'
   # Access an interactive console on exception pages or by calling `console` anywhere in the code.
-  gem 'web-console', '>= 3.3.0'
   gem 'pry'
+  gem 'web-console', '>= 3.3.0'
 end
 
 group :test do

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ApplicationController < ActionController::Base;
+class ApplicationController < ActionController::Base
   helper_method :current_user
   def current_user
     @current_user ||= User.find(session[:user_id]) if session[:user_id]

--- a/app/controllers/graphql_controller.rb
+++ b/app/controllers/graphql_controller.rb
@@ -16,7 +16,7 @@ class GraphqlController < ApplicationController
     operation_name = graphql_params[:operationName]
     context = {
       # Query context goes here, for example:
-      current_user: current_user,
+      current_user: current_user
     }
     result = MagnifierSchema.execute(
       query,

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -3,6 +3,5 @@
 # A basic controller for rendering static pages
 #
 class PagesController < ApplicationController
-  def index
-  end
+  def index; end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,6 +1,6 @@
 class SessionsController < ApplicationController
   def create
-    user = User.from_omniauth(request.env["omniauth.auth"])
+    user = User.from_omniauth(request.env['omniauth.auth'])
     session[:user_id] = user.id
     redirect_to root_path
   end

--- a/app/graphql/queries/users/me_query.rb
+++ b/app/graphql/queries/users/me_query.rb
@@ -3,7 +3,7 @@ module Queries
     class MeQuery < Queries::BaseQuery
       description 'The Logged in user'
       type Types::UserType, null: true
-      def resolve()
+      def resolve
         context[:current_user]
       end
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,6 +12,10 @@ class User < ApplicationRecord
   validates :email, presence: true, uniqueness: true
   validates :github_username, uniqueness: true
 
+  # @see https://github.com/zquestz/omniauth-google-oauth2
+  #
+  # rubocop:disable Metrics/MethodLength
+  # rubocop:disable Metrics/AbcSize
   def self.from_omniauth(auth)
     where(provider: auth.provider, uid: auth.uid).first_or_initialize.tap do |user|
       user.email = auth.info['email']
@@ -25,6 +29,8 @@ class User < ApplicationRecord
       user.save!
     end
   end
+  # rubocop:enable Metrics/MethodLength
+  # rubocop:enable Metrics/AbcSize
 
   def org
     Organization.find_by id: organization_id

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,9 +14,9 @@ class User < ApplicationRecord
 
   def self.from_omniauth(auth)
     where(provider: auth.provider, uid: auth.uid).first_or_initialize.tap do |user|
-      user.email = auth.info["email"]
-      user.first_name = auth.info["first_name"]
-      user.last_name = auth.info["last_name"]
+      user.email = auth.info['email']
+      user.first_name = auth.info['first_name']
+      user.last_name = auth.info['last_name']
       user.provider = auth.provider
       user.uid = auth.uid
       user.name = auth.info.name

--- a/app/services/github/persist.rb
+++ b/app/services/github/persist.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Github
+  class Persist
+    attr_reader :user, :datetime, :service
+
+    def initialize(user, datetime)
+      @user = user
+      @datetime = datetime
+      @service = Github::Service.new(user, datetime)
+    end
+
+    def created_issues!
+      update_or_create_stats!('issues_created')
+    end
+
+    def worked_issues!
+      update_or_create_stats!('issues_worked')
+    end
+
+    def worked_pull_requests!
+      update_or_create_stats!('pull_requests_worked')
+    end
+
+    def merged_pull_requests!
+      update_or_create_stats!('pull_requests_merged', merged: true)
+    end
+
+    private
+
+    def update_or_create_stats!(service_type, merged: false)
+      response = service.send(service_type)
+      items    = response.parsed_response['items']
+
+      items.map do |item|
+        UpdateOrCreate.new(item, user, merged: merged).statistic!
+      end
+    end
+  end
+end

--- a/app/services/github/persist.rb
+++ b/app/services/github/persist.rb
@@ -10,18 +10,38 @@ module Github
       @service = Github::Service.new(user, datetime)
     end
 
+    # Calls Github::Service#issues_created and creates/updates associated
+    # Statistic, GithubUser, and Repository records.
+    #
+    # @return [Array<Statistic>] An array of the created/updated Statistic records
+    #
     def created_issues!
       update_or_create_stats!('issues_created')
     end
 
+    # Calls Github::Service#issues_worked and creates/updates associated
+    # Statistic, GithubUser, and Repository records.
+    #
+    # @return [Array<Statistic>] An array of the created/updated Statistic records
+    #
     def worked_issues!
       update_or_create_stats!('issues_worked')
     end
 
+    # Calls Github::Service#pull_requests_worked and creates/updates associated
+    # Statistic, GithubUser, and Repository records.
+    #
+    # @return [Array<Statistic>] An array of the created/updated Statistic records
+    #
     def worked_pull_requests!
       update_or_create_stats!('pull_requests_worked')
     end
 
+    # Calls Github::Service#pull_requests_merged and creates/updates associated
+    # Statistic, GithubUser, and Repository records.
+    #
+    # @return [Array<Statistic>] An array of the created/updated Statistic records
+    #
     def merged_pull_requests!
       update_or_create_stats!('pull_requests_merged', merged: true)
     end

--- a/app/services/github/update_or_create.rb
+++ b/app/services/github/update_or_create.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+module Github
+  class UpdateOrCreate
+    attr_reader :issue, :user, :org_id, :repository_url, :repository_name, :issue_user, :issue_id, :merged
+
+    def initialize(issue, user, merged: false)
+      @issue = issue
+      @user = user
+      @org_id = org_id!(user.organization_id)
+      @repository_url = derive_repository_url
+      @repository_name = derive_repository_name
+      @issue_user = issue['user']
+      @issue_id = issue['id'].to_s
+      @merged = merged
+    end
+
+    def repository!
+      Repository.find_or_create_by!(url: repository_url) do |repo|
+        repo.organization_id = org_id
+        repo.name            = repository_name
+      end
+    end
+
+    def github_user!
+      GithubUser.find_or_create_by!(github_login: user.github_username) do |github_user|
+        github_user.oddball_employee = true
+        github_user.user_id          = user.id
+        github_user.avatar_url       = issue_user['avatar_url']
+        github_user.api_url          = issue_user['url']
+        github_user.html_url         = issue_user['html_url']
+        github_user.github_id        = issue_user['id']
+      end
+    end
+
+    # - Creates/Updates a Statistic record
+    # - Finds/Creates associated Repository record
+    # - Finds/Creates associated GithubUser record
+    #
+    def statistic!
+      statistic = Statistic.find_by(source: Statistic::GITHUB, source_id: issue_id)
+
+      if statistic
+        statistic.tap { |stat| stat.update! issue_attributes }
+      else
+        statistic = Statistic.create! issue_attributes
+
+        associate_github_user_with statistic
+      end
+    end
+
+    private
+
+    def org_id!(organization_id)
+      if organization_id.present?
+        organization_id
+      else
+        raise Github::ServiceError, 'Missing user organization'
+      end
+    end
+
+    def derive_repository_url
+      issue['repository_url'].gsub('api.', '').gsub('repos/', '')
+    end
+
+    def derive_repository_name
+      repository_url.split('/').last
+    end
+
+    def issue_type
+      issue['html_url'].include?('/issues/') ? Statistic::ISSUE : Statistic::PR
+    end
+
+    def associate_github_user_with(statistic)
+      statistic.tap do |stat|
+        stat.github_users << github_user!
+      end
+    end
+
+    def issue_attributes
+      {
+        source_id: issue_id,
+        source_type: issue_type,
+        source: Statistic::GITHUB,
+        state: state,
+        repository_id: repository!.id,
+        organization_id: org_id,
+        url: issue['html_url'],
+        title: issue['title'],
+        source_created_at: issue['created_at'],
+        source_updated_at: issue['updated_at']
+      }
+    end
+
+    def state
+      if merged
+        Statistic::MERGED
+      else
+        issue['state']
+      end
+    end
+  end
+end

--- a/app/services/github/update_or_create.rb
+++ b/app/services/github/update_or_create.rb
@@ -15,6 +15,10 @@ module Github
       @merged = merged
     end
 
+    # Based on the initialized issue and user, finds/creates a Repository record
+    #
+    # @return [Repository]
+    #
     def repository!
       Repository.find_or_create_by!(url: repository_url) do |repo|
         repo.organization_id = org_id
@@ -22,6 +26,10 @@ module Github
       end
     end
 
+    # Based on the initialized issue and user, finds/creates a GithubUser record
+    #
+    # @return [GithubUser]
+    #
     def github_user!
       GithubUser.find_or_create_by!(github_login: user.github_username) do |github_user|
         github_user.oddball_employee = true
@@ -33,9 +41,13 @@ module Github
       end
     end
 
-    # - Creates/Updates a Statistic record
-    # - Finds/Creates associated Repository record
-    # - Finds/Creates associated GithubUser record
+    # Based on the initialized issue and user, does all of the following:
+    #   - Creates/Updates a Statistic record
+    #   - Finds/Creates associated Repository record
+    #   - Finds/Creates associated GithubUser record
+    #   - Associates the Statistic Record with its GithubUser record
+    #
+    # @return [Statistic]
     #
     def statistic!
       statistic = Statistic.find_by(source: Statistic::GITHUB, source_id: issue_id)

--- a/app/services/github/update_or_create.rb
+++ b/app/services/github/update_or_create.rb
@@ -44,9 +44,9 @@ module Github
         statistic.tap { |stat| stat.update! issue_attributes }
       else
         statistic = Statistic.create! issue_attributes
-
-        associate_github_user_with statistic
       end
+
+      associate_github_user_with statistic
     end
 
     private
@@ -72,8 +72,12 @@ module Github
     end
 
     def associate_github_user_with(statistic)
-      statistic.tap do |stat|
-        stat.github_users << github_user!
+      github_user = github_user!
+
+      if statistic.github_users.include? github_user
+        statistic
+      else
+        statistic.tap { |stat| stat.github_users << github_user }
       end
     end
 

--- a/app/services/github/update_or_create.rb
+++ b/app/services/github/update_or_create.rb
@@ -52,11 +52,9 @@ module Github
     private
 
     def org_id!(organization_id)
-      if organization_id.present?
-        organization_id
-      else
-        raise Github::ServiceError, 'Missing user organization'
-      end
+      return organization_id if organization_id.present?
+
+      raise Github::ServiceError, 'Missing user organization'
     end
 
     def derive_repository_url
@@ -81,6 +79,8 @@ module Github
       end
     end
 
+    # rubocop:disable Metrics/MethodLength
+    # rubocop:disable Metrics/AbcSize
     def issue_attributes
       {
         source_id: issue_id,
@@ -96,6 +96,8 @@ module Github
         source_created_by: issue_user['id']
       }
     end
+    # rubocop:enable Metrics/MethodLength
+    # rubocop:enable Metrics/AbcSize
 
     def state
       if merged

--- a/app/services/github/update_or_create.rb
+++ b/app/services/github/update_or_create.rb
@@ -88,7 +88,8 @@ module Github
         url: issue['html_url'],
         title: issue['title'],
         source_created_at: issue['created_at'],
-        source_updated_at: issue['updated_at']
+        source_updated_at: issue['updated_at'],
+        source_created_by: issue_user['id']
       }
     end
 

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -2,13 +2,11 @@ OmniAuth.config.logger = Rails.logger
 
 Rails.application.config.middleware.use OmniAuth::Builder do
   provider(
-    :google_oauth2, 
-    Rails.application.credentials.google_auth[:client_id], 
-    Rails.application.credentials.google_auth[:client_secret], 
-    { 
-      client_options: { 
-        ssl: { ca_file: Rails.root.join("cacert.pem").to_s } 
-      } 
+    :google_oauth2,
+    Rails.application.credentials.google_auth[:client_id],
+    Rails.application.credentials.google_auth[:client_secret],
+    client_options: {
+      ssl: { ca_file: Rails.root.join('cacert.pem').to_s }
     }
   )
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
   get 'auth/failure', to: redirect('/')
   get 'signout', to: 'sessions#destroy', as: 'signout'
 
-  resources :sessions, only: [:create, :destroy]
+  resources :sessions, only: %i[create destroy]
   mount GraphiQL::Rails::Engine, at: '/graphiql', graphql_path: '/graphql' if Rails.env.development?
 
   get '*path', to: 'pages#index'

--- a/db/migrate/20181025021310_add_source_id_index_to_statistics.rb
+++ b/db/migrate/20181025021310_add_source_id_index_to_statistics.rb
@@ -1,0 +1,5 @@
+class AddSourceIdIndexToStatistics < ActiveRecord::Migration[5.2]
+  def change
+    add_index :statistics, :source_id
+  end
+end

--- a/db/migrate/20181118193554_add_created_by_to_statistics.rb
+++ b/db/migrate/20181118193554_add_created_by_to_statistics.rb
@@ -1,0 +1,6 @@
+class AddCreatedByToStatistics < ActiveRecord::Migration[5.2]
+  def change
+    add_column :statistics, :source_created_by, :integer
+    add_index :statistics, :source_created_by
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_10_20_225546) do
+ActiveRecord::Schema.define(version: 2018_10_25_021310) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -65,6 +65,7 @@ ActiveRecord::Schema.define(version: 2018_10_20_225546) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["organization_id"], name: "index_statistics_on_organization_id"
+    t.index ["source_id"], name: "index_statistics_on_source_id"
   end
 
   create_table "users", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_10_25_021310) do
+ActiveRecord::Schema.define(version: 2018_11_18_193554) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -64,7 +64,9 @@ ActiveRecord::Schema.define(version: 2018_10_25_021310) do
     t.string "source_closed_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "source_created_by"
     t.index ["organization_id"], name: "index_statistics_on_organization_id"
+    t.index ["source_created_by"], name: "index_statistics_on_source_created_by"
     t.index ["source_id"], name: "index_statistics_on_source_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -79,12 +79,12 @@ ActiveRecord::Schema.define(version: 2018_11_18_193554) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "github_username"
+    t.integer "organization_id"
     t.string "provider"
     t.string "uid"
     t.string "name"
     t.string "oauth_token"
     t.datetime "oauth_expires_at"
-    t.integer "organization_id"
     t.index ["organization_id"], name: "index_users_on_organization_id"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -57,13 +57,15 @@ people = [
     first_name: 'John',
     last_name: 'Smith',
     email: 'john@example.com',
-    github_username: 'jsmith'
+    github_username: 'jsmith',
+    organization_id: dova.id
   },
   {
     first_name: 'Susan',
     last_name: 'Williams',
     email: 'susan@example.com',
-    github_username: 'suzy'
+    github_username: 'suzy',
+    organization_id: etsy.id
   }
 ]
 
@@ -117,7 +119,8 @@ stats = [
     url: 'https://api.github.com/repos/department-of-veterans-affairs/vets.gov-team/issues/14066',
     title: 'Clean up URL parameters in View Settings',
     source_created_at: '2018-10-08T20:31:41Z',
-    source_updated_at: '2018-10-08T20:31:42Z'
+    source_updated_at: '2018-10-08T20:31:42Z',
+    source_created_by: 123456789
   },
   {
     source_id: '367942274',
@@ -130,7 +133,8 @@ stats = [
     title: 'Link on Housing hub in yellow homeless box needs to be populated',
     source_created_at: '2018-10-07T20:31:41Z',
     source_updated_at: '2018-10-09T20:31:42Z',
-    source_closed_at: '2018-10-09T50:31:42Z'
+    source_closed_at: '2018-10-09T50:31:42Z',
+    source_created_by: beth.github_id
   }
 ]
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -21,12 +21,12 @@ RSpec.describe User, type: :model do
       token = SecureRandom.hex
       authmock = OmniAuth::AuthHash.new
       authmock.info = {
-        first_name: "Jane",
-        last_name: "Doe",
-        name: "Jane Doe",
-        email: "jane.doe@gmail.com"
+        first_name: 'Jane',
+        last_name: 'Doe',
+        name: 'Jane Doe',
+        email: 'jane.doe@gmail.com'
       }
-      authmock.provider = "test"
+      authmock.provider = 'test'
       authmock.credentials = {
         token: token,
         expires_at: 1.year.from_now

--- a/spec/services/github/persist_spec.rb
+++ b/spec/services/github/persist_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Github::Persist do
         expect(Organization.count).to eq 0
         expect(GithubUser.count).to eq 0
 
-        response = Github::Persist.new(user, datetime).created_issues!
+        Github::Persist.new(user, datetime).created_issues!
 
         expect(Statistic.count).to eq 9
         expect(Repository.count).to eq 1
@@ -41,7 +41,7 @@ RSpec.describe Github::Persist do
         expect(Organization.count).to eq 0
         expect(GithubUser.count).to eq 0
 
-        response = Github::Persist.new(user, datetime).worked_issues!
+        Github::Persist.new(user, datetime).worked_issues!
 
         expect(Statistic.count).to eq 62
         expect(Repository.count).to eq 1
@@ -68,7 +68,7 @@ RSpec.describe Github::Persist do
         expect(Organization.count).to eq 0
         expect(GithubUser.count).to eq 0
 
-        response = Github::Persist.new(user, datetime).worked_pull_requests!
+        Github::Persist.new(user, datetime).worked_pull_requests!
 
         expect(Statistic.count).to eq 2
         expect(Repository.count).to eq 2
@@ -96,7 +96,7 @@ RSpec.describe Github::Persist do
         expect(Organization.count).to eq 0
         expect(GithubUser.count).to eq 0
 
-        response = Github::Persist.new(user, datetime).merged_pull_requests!
+        Github::Persist.new(user, datetime).merged_pull_requests!
 
         expect(Statistic.count).to eq 20
         expect(Repository.count).to eq 5

--- a/spec/services/github/persist_spec.rb
+++ b/spec/services/github/persist_spec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Github::Persist do
+  let(:datetime) { '2018-09-01T20:43:46Z' }
+  let(:personal_access_token) { SecureRandom.hex(16) }
+  let(:org_name) { 'department-of-veterans-affairs' }
+  let(:org) { create :organization, name: org_name }
+
+  let(:github_username) { 'hpjaj' }
+  let(:user) do
+    create(
+      :user,
+      github_username: github_username,
+      organization_id: org.id,
+      personal_access_token: personal_access_token
+    )
+  end
+
+  describe '#created_issues!' do
+    it 'creates statistics for all of the issues from the GitHub API response', :aggregate_failures do
+      VCR.use_cassette 'github/issues_created/success' do
+        expect(Statistic.count).to eq 0
+        expect(Repository.count).to eq 0
+        expect(Organization.count).to eq 0
+        expect(GithubUser.count).to eq 0
+
+        response = Github::Persist.new(user, datetime).created_issues!
+
+        expect(Statistic.count).to eq 9
+        expect(Repository.count).to eq 1
+        expect(Organization.count).to eq 1
+        expect(GithubUser.count).to eq 1
+
+        expect(response.map { |stat| stat.class.to_s }.uniq).to eq ['Statistic']
+        expect(response.map(&:source_type).uniq).to eq [Statistic::ISSUE]
+      end
+    end
+  end
+
+  describe '#worked_issues!' do
+    it 'creates statistics for all of the issues from the GitHub API response', :aggregate_failures do
+      VCR.use_cassette 'github/issues_worked/success' do
+        expect(Statistic.count).to eq 0
+        expect(Repository.count).to eq 0
+        expect(Organization.count).to eq 0
+        expect(GithubUser.count).to eq 0
+
+        response = Github::Persist.new(user, datetime).worked_issues!
+
+        expect(Statistic.count).to eq 62
+        expect(Repository.count).to eq 1
+        expect(Organization.count).to eq 1
+        expect(GithubUser.count).to eq 1
+
+        expect(response.map { |stat| stat.class.to_s }.uniq).to eq ['Statistic']
+        expect(response.map(&:source_type).uniq).to eq [Statistic::ISSUE]
+      end
+    end
+  end
+
+  describe '#worked_pull_requests!' do
+    it 'creates statistics for all of the PRs from the GitHub API response', :aggregate_failures do
+      VCR.use_cassette 'github/pull_requests_worked/success' do
+        expect(Statistic.count).to eq 0
+        expect(Repository.count).to eq 0
+        expect(Organization.count).to eq 0
+        expect(GithubUser.count).to eq 0
+
+        response = Github::Persist.new(user, datetime).worked_pull_requests!
+
+        expect(Statistic.count).to eq 2
+        expect(Repository.count).to eq 2
+        expect(Organization.count).to eq 1
+        expect(GithubUser.count).to eq 1
+
+        expect(response.map { |stat| stat.class.to_s }.uniq).to eq ['Statistic']
+        expect(response.map(&:source_type).uniq).to eq [Statistic::PR]
+        expect(response.map(&:state).uniq).to eq [Statistic::OPEN]
+      end
+    end
+  end
+
+  describe '#merged_pull_requests!' do
+    it 'creates statistics for all of the PRs from the GitHub API response', :aggregate_failures do
+      VCR.use_cassette 'github/pull_requests_merged/success' do
+        expect(Statistic.count).to eq 0
+        expect(Repository.count).to eq 0
+        expect(Organization.count).to eq 0
+        expect(GithubUser.count).to eq 0
+
+        response = Github::Persist.new(user, datetime).merged_pull_requests!
+
+        expect(Statistic.count).to eq 20
+        expect(Repository.count).to eq 5
+        expect(Organization.count).to eq 1
+        expect(GithubUser.count).to eq 1
+
+        expect(response.map { |stat| stat.class.to_s }.uniq).to eq ['Statistic']
+        expect(response.map(&:source_type).uniq).to eq [Statistic::PR]
+        expect(response.map(&:state).uniq).to eq [Statistic::MERGED]
+      end
+    end
+  end
+end

--- a/spec/services/github/service_spec.rb
+++ b/spec/services/github/service_spec.rb
@@ -1,21 +1,10 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require_relative '../../support/github_setup'
 
 RSpec.describe Github::Service do
-  let(:datetime) { '2018-09-01T20:43:46Z' }
-  let(:personal_access_token) { SecureRandom.hex(16) }
-  let(:org_name) { 'department-of-veterans-affairs' }
-  let(:org) { create :organization, name: org_name }
-  let(:github_username) { 'hpjaj' }
-  let(:user) do
-    create(
-      :user,
-      github_username: github_username,
-      organization_id: org.id,
-      personal_access_token: personal_access_token
-    )
-  end
+  setup_github_org_and_user
 
   context 'authorization criteria' do
     it 'will raise an error when user.github_username is not present' do

--- a/spec/services/github/update_or_create_spec.rb
+++ b/spec/services/github/update_or_create_spec.rb
@@ -118,6 +118,36 @@ RSpec.describe Github::UpdateOrCreate do
         expect(statistic.source_updated_at).to eq issue['updated_at']
         expect(statistic.source_created_by).to eq issue_user['id']
       end
+
+      context 'when the GithubUser is *not* already associated with the Statistic' do
+        it 'creates an association between the GithubUser and the Statistic' do
+          github_user = GithubUser.first
+          statistic   = Statistic.first
+
+          expect(statistic.github_users).to eq [github_user]
+          statistic.github_users.delete github_user
+          expect(statistic.github_users).to eq []
+
+          updated_statistic = Github::UpdateOrCreate.new(issue, user).statistic!
+
+          expect(updated_statistic).to eq statistic
+          expect(updated_statistic.github_users).to eq [github_user]
+        end
+      end
+
+      context 'when the GithubUser is already associated with the Statistic' do
+        it 'does not duplicate the association' do
+          github_user = GithubUser.first
+          statistic   = Statistic.first
+
+          expect(statistic.github_users).to eq [github_user]
+
+          updated_statistic = Github::UpdateOrCreate.new(issue, user).statistic!
+
+          expect(updated_statistic).to eq statistic
+          expect(updated_statistic.github_users).to eq [github_user]
+        end
+      end
     end
 
     context 'when the Statistic does not exist' do

--- a/spec/services/github/update_or_create_spec.rb
+++ b/spec/services/github/update_or_create_spec.rb
@@ -1,0 +1,253 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Github::UpdateOrCreate do
+  let(:datetime) { '2018-09-01T20:43:46Z' }
+  let(:personal_access_token) { SecureRandom.hex(16) }
+  let(:org_name) { 'department-of-veterans-affairs' }
+  let(:org) { create :organization, name: org_name }
+
+  let(:github_username) { 'hpjaj' }
+  let(:user) do
+    create(
+      :user,
+      github_username: github_username,
+      organization_id: org.id,
+      personal_access_token: personal_access_token
+    )
+  end
+  let!(:issue) do
+    VCR.use_cassette 'github/issues_created/success' do
+      response = Github::Service.new(user, datetime).issues_created
+      body     = JSON.parse response.body
+
+      body['items'].first
+    end
+  end
+  let(:issue_repo) { issue['repository_url'].split("#{org_name}/").last }
+  let(:issue_user) { issue['user'] }
+
+  describe '#initialize' do
+    it 'will raise an error when user.organization_id is not present' do
+      invalid_user = build :user, organization_id: nil
+
+      expect do
+        Github::UpdateOrCreate.new(issue, invalid_user)
+      end.to raise_error Github::ServiceError
+    end
+  end
+
+  describe '#repository!' do
+    context 'when the repository already exists' do
+      before { existing_repository }
+
+      it 'returns the repository record with the response data', :aggregate_failures do
+        repository = Github::UpdateOrCreate.new(issue, user).repository!
+
+        expect(repository.name).to eq issue_repo
+        expect(repository.url).to eq repository_url
+        expect(repository.organization_id).to eq org.id
+        expect(Repository.count).to eq 1
+      end
+    end
+
+    context 'when the repository does not exist' do
+      it 'creates and returns a repository record with the response data', :aggregate_failures do
+        expect(Repository.count).to eq 0
+
+        repository = Github::UpdateOrCreate.new(issue, user).repository!
+
+        expect(repository.name).to eq issue_repo
+        expect(repository.url).to eq repository_url
+        expect(repository.organization_id).to eq org.id
+        expect(Repository.count).to eq 1
+      end
+    end
+  end
+
+  describe '#github_user!' do
+    context 'when the GithubUser already exists' do
+      before { existing_github_user }
+
+      it 'returns the GithubUser record with the response data', :aggregate_failures do
+        expect(GithubUser.count).to eq 1
+
+        github_user = Github::UpdateOrCreate.new(issue, user).github_user!
+
+        expect(GithubUser.count).to eq 1
+        expect(github_user.github_login). to eq user.github_username
+      end
+    end
+
+    context 'when the GithubUser does not exist' do
+      it 'creates and returns the GithubUser record with the response data', :aggregate_failures do
+        expect(GithubUser.count).to eq 0
+
+        github_user = Github::UpdateOrCreate.new(issue, user).github_user!
+
+        expect(GithubUser.count).to eq 1
+        expect(github_user).to be_valid
+        expect(github_user.github_login). to eq user.github_username
+        expect(github_user.user_id). to eq user.id
+        expect(github_user.avatar_url). to eq issue_user['avatar_url']
+        expect(github_user.api_url). to eq issue_user['url']
+        expect(github_user.html_url). to eq issue_user['html_url']
+        expect(github_user.github_id). to eq issue_user['id']
+        expect(github_user.oddball_employee). to eq true
+      end
+    end
+  end
+
+  describe '#statistic!' do
+    context 'when the Statistic already exists' do
+      before do
+        create :repository, name: repository_name, organization_id: org.id, url: repository_url
+      end
+      let!(:stat) { existing_statistic }
+
+      it 'updates and returns the Statistic record with the response data', :aggregate_failures do
+        expect(Statistic.count).to eq 1
+        expect(stat.state).to eq Statistic::CLOSED
+        expect(stat.source_created_at).to eq initial_datetime
+        expect(stat.source_updated_at).to eq initial_datetime
+
+        statistic = Github::UpdateOrCreate.new(issue, user).statistic!
+
+        expect(Statistic.count).to eq 1
+        expect(stat.id).to eq statistic.id
+        expect(statistic).to be_valid
+        expect(statistic.source_id).to eq issue['id'].to_s
+        expect(statistic.source_type).to eq issue_type_for(issue)
+        expect(statistic.source).to eq Statistic::GITHUB
+        expect(statistic.state).to eq issue['state']
+        expect(statistic.repository_id).to eq repository_id
+        expect(statistic.organization_id).to eq user.organization_id
+        expect(statistic.url).to eq issue['html_url']
+        expect(statistic.title).to eq issue['title']
+        expect(statistic.source_created_at).to eq issue['created_at']
+        expect(statistic.source_updated_at).to eq issue['updated_at']
+      end
+    end
+
+    context 'when the Statistic does not exist' do
+      it 'creates and returns the Statistic record with the response data', :aggregate_failures do
+        expect(Statistic.count).to eq 0
+
+        statistic = Github::UpdateOrCreate.new(issue, user).statistic!
+
+        expect(Statistic.count).to eq 1
+        expect(statistic).to be_valid
+        expect(statistic.source_id).to eq issue['id'].to_s
+        expect(statistic.source_type).to eq issue_type_for(issue)
+        expect(statistic.source).to eq Statistic::GITHUB
+        expect(statistic.state).to eq issue['state']
+        expect(statistic.repository_id).to eq repository_id
+        expect(statistic.organization_id).to eq user.organization_id
+        expect(statistic.url).to eq issue['html_url']
+        expect(statistic.title).to eq issue['title']
+        expect(statistic.source_created_at).to eq issue['created_at']
+        expect(statistic.source_updated_at).to eq issue['updated_at']
+      end
+
+      it 'creates the associated Githubuser record, if one does not already exist', :aggregate_failures do
+        expect(GithubUser.count).to eq 0
+
+        statistic = Github::UpdateOrCreate.new(issue, user).statistic!
+
+        expect(GithubUser.count).to eq 1
+        expect(statistic.github_users.first).to eq GithubUser.first
+      end
+
+      it 'creates the associated Repository record, if one does not already exist', :aggregate_failures do
+        expect(Repository.count).to eq 0
+
+        statistic = Github::UpdateOrCreate.new(issue, user).statistic!
+
+        expect(Repository.count).to eq 1
+        expect(statistic.repository_id).to eq Repository.first.id
+      end
+
+      it 'associates the Statistic with its GithubUser', :aggregate_failures do
+        expect(GithubUser.count).to eq 0
+
+        statistic    = Github::UpdateOrCreate.new(issue, user).statistic!
+        github_users = statistic.github_users
+        github_user  = GithubUser.first
+
+        expect(github_users).to be_present
+        expect(github_users.first).to eq github_user
+      end
+    end
+  end
+end
+
+def existing_repository
+  create(
+    :repository,
+    name: issue_repo,
+    url: "https://github.com/#{org_name}/#{issue_repo}",
+    organization_id: org.id
+  )
+end
+
+def existing_github_user
+  create(
+    :github_user,
+    user_id: user.id,
+    github_login: user.github_username,
+    avatar_url: issue_user['avatar_url'],
+    api_url: issue_user['url'],
+    html_url:  issue_user['html_url'],
+    github_id: issue_user['id'],
+    oddball_employee: true
+  )
+end
+
+def issue_type_for(response)
+  response['url'].include?('/issues/') ? Statistic::ISSUE : Statistic::PR
+end
+
+def repository_url
+  issue['repository_url'].gsub('api.', '').gsub('repos/', '')
+end
+
+def repository_name
+  repository_url.split('/').last
+end
+
+def repository_id
+  Repository.find_by(name: repository_name).id
+end
+
+def existing_statistic
+  statistic = Statistic.create(
+    source_id: issue['id'].to_s,
+    source_type: issue_type_for(issue),
+    source: Statistic::GITHUB,
+    state: Statistic::CLOSED,
+    repository_id: repository_id,
+    organization_id: user.organization_id,
+    url: issue['html_url'],
+    title: issue['title'],
+    source_created_at: initial_datetime,
+    source_updated_at: initial_datetime
+  )
+
+  github_user = create(
+    :github_user,
+    github_login: github_username,
+    github_id: issue_user['id'],
+    user_id: user.id
+  )
+  statistic.github_users << github_user
+  statistic
+end
+
+def initial_datetime
+  datetime = issue['created_at']
+  datetime = Time.parse datetime
+  datetime = datetime - 1.day
+
+  datetime.iso8601
+end

--- a/spec/services/github/update_or_create_spec.rb
+++ b/spec/services/github/update_or_create_spec.rb
@@ -1,22 +1,11 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require_relative '../../support/github_setup'
 
 RSpec.describe Github::UpdateOrCreate do
-  let(:datetime) { '2018-09-01T20:43:46Z' }
-  let(:personal_access_token) { SecureRandom.hex(16) }
-  let(:org_name) { 'department-of-veterans-affairs' }
-  let(:org) { create :organization, name: org_name }
+  setup_github_org_and_user
 
-  let(:github_username) { 'hpjaj' }
-  let(:user) do
-    create(
-      :user,
-      github_username: github_username,
-      organization_id: org.id,
-      personal_access_token: personal_access_token
-    )
-  end
   let!(:issue) do
     VCR.use_cassette 'github/issues_created/success' do
       response = Github::Service.new(user, datetime).issues_created
@@ -250,7 +239,7 @@ end
 def initial_datetime
   datetime = issue['created_at']
   datetime = Time.parse datetime
-  datetime = datetime - 1.day
+  datetime -= 1.day
 
   datetime.iso8601
 end

--- a/spec/services/github/update_or_create_spec.rb
+++ b/spec/services/github/update_or_create_spec.rb
@@ -127,6 +127,7 @@ RSpec.describe Github::UpdateOrCreate do
         expect(statistic.title).to eq issue['title']
         expect(statistic.source_created_at).to eq issue['created_at']
         expect(statistic.source_updated_at).to eq issue['updated_at']
+        expect(statistic.source_created_by).to eq issue_user['id']
       end
     end
 
@@ -148,6 +149,7 @@ RSpec.describe Github::UpdateOrCreate do
         expect(statistic.title).to eq issue['title']
         expect(statistic.source_created_at).to eq issue['created_at']
         expect(statistic.source_updated_at).to eq issue['updated_at']
+        expect(statistic.source_created_by).to eq issue_user['id']
       end
 
       it 'creates the associated Githubuser record, if one does not already exist', :aggregate_failures do
@@ -231,7 +233,8 @@ def existing_statistic
     url: issue['html_url'],
     title: issue['title'],
     source_created_at: initial_datetime,
-    source_updated_at: initial_datetime
+    source_updated_at: initial_datetime,
+    source_created_by: issue_user['id']
   )
 
   github_user = create(

--- a/spec/support/github_setup.rb
+++ b/spec/support/github_setup.rb
@@ -1,0 +1,15 @@
+def setup_github_org_and_user
+  let(:datetime) { '2018-09-01T20:43:46Z' }
+  let(:personal_access_token) { SecureRandom.hex(16) }
+  let(:org_name) { 'department-of-veterans-affairs' }
+  let(:org) { create :organization, name: org_name }
+  let(:github_username) { 'hpjaj' }
+  let(:user) do
+    create(
+      :user,
+      github_username: github_username,
+      organization_id: org.id,
+      personal_access_token: personal_access_token
+    )
+  end
+end


### PR DESCRIPTION
## Background
In our daily rake tasks, we will be fetching issue and PR data directly from GitHub's API through our `Githhub::Service` object calls.  This data needs to be persisted to our database in our db tables respectively:

- `Statistic`
- `GithubUser`
- `Organization`
- `Repository`
 
## Issue Resolved
<!-- Keeping the format 'Issue #123' will automatically link & close the associated issue when this PR is merged -->
Issue #51 
 
## Definition of Done
 
- [x] Logic that takes the responses from our [Github::Service](https://github.com/oddballio/magnifier/blob/master/app/services/github/service.rb) calls, and smartly persists them to the approriate db table
- [x] Spec coverage
- [x] Yard docs
