### PR TITLE
Rake task for cron job to call daily to fetch & save all GitHub data

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -49,6 +49,7 @@ Metrics/BlockLength:
   Exclude:
     - 'db/schema.rb'
     - spec/**/*
+    - lib/tasks/**/*
 
 Style/NumericLiterals:
   Exclude:

--- a/app/services/github/update_or_create.rb
+++ b/app/services/github/update_or_create.rb
@@ -81,6 +81,7 @@ module Github
         title: issue['title'],
         source_created_at: issue['created_at'],
         source_updated_at: issue['updated_at'],
+        source_closed_at: issue['closed_at'],
         source_created_by: issue_user['id'],
         assignees: derive_assignees
       }

--- a/lib/tasks/github.rake
+++ b/lib/tasks/github.rake
@@ -1,0 +1,57 @@
+namespace :github do
+  desc <<-DESCRIPTION
+    Fetchs all of the issue and pull request activity for our users.
+    It then converts this data into the appropriate db records.
+
+    By default, it will grab any acitivty since yesterday.  If you need
+    to go back further, you can pass in a specific datetime.  The datetime
+    must be in this format:
+
+    '2018-11-26T00:00:00Z'
+
+    Here is how to call this rake task, passing in a datetime:
+
+    rake 'github:fetch_and_save_data[2018-11-26T00:00:00Z]'
+  DESCRIPTION
+  task :fetch_and_save_data, [:datetime] => :environment do |_t, args|
+    yesterday = Date.yesterday.beginning_of_day.iso8601
+    datetime  = args.datetime || yesterday
+    users     = User.where.not(
+      encrypted_personal_access_token: nil,
+      github_username: nil,
+      organization_id: nil
+    )
+    tracking = {
+      datetime: datetime,
+      users: users.count,
+      created_issues: 0,
+      worked_issues: 0,
+      worked_pull_requests: 0,
+      merged_pull_requests: 0,
+      errors: 0
+    }
+
+    users.each do |user|
+      persist = Github::Persist.new(user, datetime)
+
+      created_issues       = persist.created_issues!
+      worked_issues        = persist.worked_issues!
+      worked_pull_requests = persist.worked_pull_requests!
+      merged_pull_requests = persist.merged_pull_requests!
+
+      tracking[:created_issues]       += created_issues.count
+      tracking[:worked_issues]        += worked_issues.count
+      tracking[:worked_pull_requests] += worked_pull_requests.count
+      tracking[:merged_pull_requests] += merged_pull_requests.count
+    rescue StandardError => e
+      tracking[:errors] += 1
+      message = "When fetching/saving GitHub data for user #{user.id}, experienced this error: #{e}"
+
+      p message
+      Rails.logger.error message
+    end
+
+    p tracking
+    Rails.logger.info tracking.to_s
+  end
+end

--- a/lib/tasks/github.rake
+++ b/lib/tasks/github.rake
@@ -3,7 +3,7 @@ namespace :github do
     Fetchs all of the issue and pull request activity for our users.
     It then converts this data into the appropriate db records.
 
-    By default, it will grab any acitivty since yesterday.  If you need
+    By default, it will grab any activity since yesterday.  If you need
     to go back further, you can pass in a specific datetime.  The datetime
     must be in this format:
 

--- a/spec/services/github/update_or_create_spec.rb
+++ b/spec/services/github/update_or_create_spec.rb
@@ -77,6 +77,7 @@ RSpec.describe Github::UpdateOrCreate do
         expect(statistic.title).to eq issue['title']
         expect(statistic.source_created_at).to eq issue['created_at']
         expect(statistic.source_updated_at).to eq issue['updated_at']
+        expect(statistic.source_closed_at).to eq issue['closed_at']
         expect(statistic.source_created_by).to eq issue_user['id']
       end
 


### PR DESCRIPTION
## Background
<!-- What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary -->
We need a rake task that can be called one a day, to get the previous day's worth of GitHub user data. This will fetch all of our user's issues and pull request activity, for the previous day.

## Issue Resolved
<!-- Keeping the format 'Issue #123' will automatically link & close the associated issue when this PR is merged -->
Issue #58 
 
## Definition of Done
 
- [x] Rake task that fetches and saves all user's GitHub data for the previous day
