### PR TITLE
Saves the returned statistics to the database as the default week in review

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -64,6 +64,7 @@ Metrics/MethodLength:
   Exclude:
     - app/controllers/graphql_controller.rb
     - spec/**/*
+    - 'db/**/*'
 
 Style/Documentation:
   Enabled: false
@@ -72,3 +73,4 @@ Metrics/AbcSize:
   Exclude:
     - app/controllers/graphql_controller.rb
     - spec/**/*
+    - 'db/**/*'

--- a/app/models/accomplishment.rb
+++ b/app/models/accomplishment.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class Accomplishment < ApplicationRecord
+  # actions
+  CREATED = 'created'
+  WORKED = 'worked'
+  CLOSED = 'closed'
+  MERGED = 'merged'
+
+  belongs_to :week_in_review
+  belongs_to :statistic
+  belongs_to :user
+
+  validates :week_in_review_id, :statistic_id, :user_id, :type, :action, presence: true
+
+  # TODO: Need to define business case here before enforcing this.
+  # Meaning can an issue/PR appear in more than one area (i.e. same
+  # issue under 'issues worked' and 'issues closed', etc.)
+  #
+  # validates(
+  #   :statistic_id,
+  #   uniqueness: {
+  #     scope: :week_in_review_id,
+  #     message: 'This statistic is already present in this week in review'
+  #   }
+  # )
+end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class Comment < ApplicationRecord
+  # types
+  CONCERNS = 'concerns'
+  WEEK_GO  = 'week-go'
+  ODDBALL  = 'oddball-team'
+  PROJECT  = 'project-team'
+
+  belongs_to :week_in_review
+  belongs_to :user
+
+  validates :body, :week_in_review_id, :type, :user_id, presence: true
+  validates(
+    :type,
+    uniqueness: {
+      scope: :week_in_review_id,
+      message: 'This user already has a comment of this type for this week'
+    }
+  )
+end

--- a/app/models/statistic.rb
+++ b/app/models/statistic.rb
@@ -30,6 +30,8 @@ class Statistic < ApplicationRecord
   CLOSED_AFTER  = 'closed_after'
 
   has_and_belongs_to_many :github_users
+  has_many :accomplishments
+  has_many :week_in_reviews, through: :accomplishments
   belongs_to :organization
   belongs_to :repository
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,6 +10,9 @@ class User < ApplicationRecord
                  encode: true
 
   has_many :week_in_reviews
+  has_many :comments
+  has_many :accomplishments
+
   validates :first_name, :last_name, presence: true
   validates :email, presence: true, uniqueness: true
   validates :github_username, uniqueness: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,6 +8,8 @@ class User < ApplicationRecord
   attr_encrypted :personal_access_token,
                  key: Rails.application.credentials.encryption_key,
                  encode: true
+
+  has_many :week_in_reviews
   validates :first_name, :last_name, presence: true
   validates :email, presence: true, uniqueness: true
   validates :github_username, uniqueness: true

--- a/app/models/week_in_review.rb
+++ b/app/models/week_in_review.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class WeekInReview < ApplicationRecord
+  has_many :accomplishments
+  has_many :statistics, through: :accomplishments
+  has_many :comments
+  belongs_to :user
+
+  validates :start_date, :end_date, :user_id, presence: true
+  validates(
+    :start_date,
+    uniqueness: {
+      scope: :user_id,
+      message: 'This user already has a week in review for this week'
+    }
+  )
+end

--- a/db/migrate/20181010154342_create_github_user_and_statistic_tables.rb
+++ b/db/migrate/20181010154342_create_github_user_and_statistic_tables.rb
@@ -1,6 +1,3 @@
-# rubocop:disable Metrics/AbcSize
-# rubocop:disable Metrics/MethodLength
-
 class CreateGithubUserAndStatisticTables < ActiveRecord::Migration[5.1]
   def change
     create_table :github_users do |t|
@@ -37,6 +34,3 @@ class CreateGithubUserAndStatisticTables < ActiveRecord::Migration[5.1]
     end
   end
 end
-
-# rubocop:enable Metrics/AbcSize
-# rubocop:enable Metrics/MethodLength

--- a/db/migrate/20181208163533_create_week_in_review_accomplishments_comments.rb
+++ b/db/migrate/20181208163533_create_week_in_review_accomplishments_comments.rb
@@ -1,0 +1,27 @@
+class CreateWeekInReviewAccomplishmentsComments < ActiveRecord::Migration[5.2]
+  def change
+    create_table :week_in_reviews do |t|
+      t.date :start_date
+      t.date :end_date
+      t.references :user, foreign_key: true
+      t.timestamps
+    end
+
+    create_table :accomplishments do |t|
+      t.belongs_to :week_in_review, index: true
+      t.belongs_to :statistic, index: true
+      t.string :type
+      t.string :action
+      t.references :user, foreign_key: true
+      t.timestamps
+    end
+
+    create_table :comments do |t|
+      t.references :week_in_review, foreign_key: true
+      t.text :body
+      t.string :type
+      t.references :user, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,34 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_11_24_020711) do
+ActiveRecord::Schema.define(version: 2018_12_08_163533) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "accomplishments", force: :cascade do |t|
+    t.bigint "week_in_review_id"
+    t.bigint "statistic_id"
+    t.string "type"
+    t.string "action"
+    t.bigint "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["statistic_id"], name: "index_accomplishments_on_statistic_id"
+    t.index ["user_id"], name: "index_accomplishments_on_user_id"
+    t.index ["week_in_review_id"], name: "index_accomplishments_on_week_in_review_id"
+  end
+
+  create_table "comments", force: :cascade do |t|
+    t.bigint "week_in_review_id"
+    t.text "body"
+    t.string "type"
+    t.bigint "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_comments_on_user_id"
+    t.index ["week_in_review_id"], name: "index_comments_on_week_in_review_id"
+  end
 
   create_table "github_users", force: :cascade do |t|
     t.integer "user_id"
@@ -90,6 +114,19 @@ ActiveRecord::Schema.define(version: 2018_11_24_020711) do
     t.index ["organization_id"], name: "index_users_on_organization_id"
   end
 
+  create_table "week_in_reviews", force: :cascade do |t|
+    t.date "start_date"
+    t.date "end_date"
+    t.bigint "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_week_in_reviews_on_user_id"
+  end
+
+  add_foreign_key "accomplishments", "users"
+  add_foreign_key "comments", "users"
+  add_foreign_key "comments", "week_in_reviews"
   add_foreign_key "repositories", "organizations"
   add_foreign_key "statistics", "organizations"
+  add_foreign_key "week_in_reviews", "users"
 end

--- a/spec/factories/accomplishments.rb
+++ b/spec/factories/accomplishments.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :accomplishment do
+    week_in_review
+    statistic { FactoryBot.create(:statistic, :open_issue) }
+    user
+    type { Statistic::ISSUE }
+    action { Accomplishment::WORKED }
+  end
+end

--- a/spec/factories/comments.rb
+++ b/spec/factories/comments.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :comment do
+    week_in_review
+    user
+    body { 'Some comment' }
+    type { Comment::CONCERNS }
+  end
+end

--- a/spec/factories/week_in_reviews.rb
+++ b/spec/factories/week_in_reviews.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :week_in_review do
+    start_date { '2018-11-26' }
+    end_date { '2018-12-02' }
+    user
+  end
+end

--- a/spec/models/accomplishment_spec.rb
+++ b/spec/models/accomplishment_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Accomplishment, type: :model do
+  describe 'validations' do
+    it 'has a valid factory' do
+      accomplishment = create :accomplishment
+
+      expect(accomplishment).to be_valid
+    end
+
+    it { should validate_presence_of(:week_in_review_id) }
+    it { should validate_presence_of(:statistic_id) }
+    it { should validate_presence_of(:user_id) }
+    it { should validate_presence_of(:type) }
+    it { should validate_presence_of(:action) }
+  end
+
+  describe 'associations' do
+    it { should belong_to(:week_in_review) }
+    it { should belong_to(:statistic) }
+    it { should belong_to(:user) }
+  end
+end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Comment, type: :model do
+  describe 'validations' do
+    it 'has a valid factory' do
+      comment = create :comment
+
+      expect(comment).to be_valid
+    end
+
+    it { should validate_presence_of(:body) }
+    it { should validate_presence_of(:type) }
+    it { should validate_presence_of(:week_in_review_id) }
+    it { should validate_presence_of(:user_id) }
+
+    context 'there can only be one type of comment per week_in_review_id' do
+      it 'raises an error if a duplicate is created', :aggregate_failures do
+        user = create :user
+        wir  = create :week_in_review, user: user
+        comment1 = create :comment, week_in_review: wir, type: Comment::ODDBALL, user: user
+        comment2 = create :comment, week_in_review: wir, type: Comment::PROJECT, user: user
+
+        expect(comment1).to be_valid
+        expect(comment2).to be_valid
+
+        expect do
+          create :comment, week_in_review: wir, type: Comment::ODDBALL, user: user
+        end.to raise_error(
+          ActiveRecord::RecordInvalid,
+          'Validation failed: Type This user already has a comment of this type for this week'
+        )
+      end
+    end
+  end
+
+  describe 'associations' do
+    it { should belong_to(:week_in_review) }
+    it { should belong_to(:user) }
+  end
+end

--- a/spec/models/statistic_spec.rb
+++ b/spec/models/statistic_spec.rb
@@ -24,6 +24,8 @@ RSpec.describe Statistic, type: :model do
 
   describe 'associations' do
     it { should have_and_belong_to_many(:github_users) }
+    it { should have_many(:week_in_reviews) }
+    it { should have_many(:accomplishments) }
     it { should belong_to(:repository) }
     it { should belong_to(:organization) }
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -15,6 +15,11 @@ RSpec.describe User, type: :model do
     it { should validate_uniqueness_of(:email) }
     it { should validate_uniqueness_of(:github_username) }
   end
+
+  describe 'associations' do
+    it { should have_many(:week_in_reviews) }
+  end
+
   describe 'from_omniauth' do
     it 'has a method that requires an auth obj from omniauth2' do
       count = User.count

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe User, type: :model do
 
   describe 'associations' do
     it { should have_many(:week_in_reviews) }
+    it { should have_many(:accomplishments) }
   end
 
   describe 'from_omniauth' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe User, type: :model do
   end
 
   describe 'associations' do
+    it { should have_many(:comments) }
     it { should have_many(:week_in_reviews) }
     it { should have_many(:accomplishments) }
   end

--- a/spec/models/week_in_review_spec.rb
+++ b/spec/models/week_in_review_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe WeekInReview, type: :model do
+  describe 'validations' do
+    it 'has a valid factory' do
+      week_in_review = create :week_in_review
+
+      expect(week_in_review).to be_valid
+    end
+
+    it { should validate_presence_of(:start_date) }
+    it { should validate_presence_of(:end_date) }
+    it { should validate_presence_of(:user_id) }
+
+    context 'there can only be one week in review per user, per week' do
+      it 'raises an error if a duplicate week in review is created', :aggregate_failures do
+        start_date = '2018-11-26'
+        john = create :user
+        mary = create :user
+        john_week_in_review = create :week_in_review, user: john, start_date: start_date
+        mary_week_in_review = create :week_in_review, user: mary, start_date: start_date
+
+        expect(john_week_in_review).to be_valid
+        expect(mary_week_in_review).to be_valid
+
+        expect { create :week_in_review, user: john, start_date: start_date }.to raise_error(
+          ActiveRecord::RecordInvalid,
+          'Validation failed: Start date This user already has a week in review for this week'
+        )
+      end
+    end
+  end
+
+  describe 'associations' do
+    it { should have_many(:accomplishments) }
+    it { should have_many(:statistics) }
+    it { should have_many(:comments) }
+    it { should belong_to(:user) }
+  end
+end


### PR DESCRIPTION
## Background
We are currently getting back a list of `Statistic`s for a given time period (i.e. this week, last week, etc.), broken out into the 6 MVP categories (i.e. issues created, issues worked, etc.).  

We need to be able to persist all of these statistics as a user's "week in review".  For this first iteration, we'll work with "this week's" statistics.

## Issue Resolved
<!-- Keeping the format 'Issue #123' will automatically link & close the associated issue when this PR is merged -->
Issue #62 
 
## Definition of Done
 
- [ ] database tables for persisting the week in review
- [ ] a page that defaults to the current user's proposed week in review statistics
- [ ] current proposed statistics are saved to the database as their initial week in review
