### PR TITLE
Week in review stats by week for current user

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -50,6 +50,7 @@ Metrics/BlockLength:
     - 'db/schema.rb'
     - spec/**/*
     - lib/tasks/**/*
+    - Guardfile
 
 Style/NumericLiterals:
   Exclude:

--- a/Guardfile
+++ b/Guardfile
@@ -24,8 +24,8 @@
 #  * zeus: 'zeus rspec' (requires the server to be started separately)
 #  * 'just' rspec: 'rspec'
 
-guard :rspec, cmd: "bundle exec rspec" do
-  require "guard/rspec/dsl"
+guard :rspec, cmd: 'bundle exec rspec' do
+  require 'guard/rspec/dsl'
   dsl = Guard::RSpec::Dsl.new(self)
 
   # Feel free to open issues for suggestions and improvements
@@ -41,7 +41,7 @@ guard :rspec, cmd: "bundle exec rspec" do
   dsl.watch_spec_files_for(ruby.lib_files)
 
   # Rails files
-  rails = dsl.rails(view_extensions: %w(erb haml slim))
+  rails = dsl.rails(view_extensions: %w[erb haml slim])
   dsl.watch_spec_files_for(rails.app_files)
   dsl.watch_spec_files_for(rails.views)
 
@@ -65,6 +65,6 @@ guard :rspec, cmd: "bundle exec rspec" do
   # Turnip features and steps
   watch(%r{^spec/acceptance/(.+)\.feature$})
   watch(%r{^spec/acceptance/steps/(.+)_steps\.rb$}) do |m|
-    Dir[File.join("**/#{m[1]}.feature")][0] || "spec/acceptance"
+    Dir[File.join("**/#{m[1]}.feature")][0] || 'spec/acceptance'
   end
 end

--- a/app/graphql/mutations/accomplishments/delete_accomplishment_mutation.rb
+++ b/app/graphql/mutations/accomplishments/delete_accomplishment_mutation.rb
@@ -13,10 +13,7 @@ module Mutations
       field :errors, [String], null: true
 
       def resolve(statistic_id:, week_in_review_id:)
-        accomplishment = Accomplishment.find_by(
-          statistic_id: statistic_id,
-          week_in_review_id: week_in_review_id
-        )
+        accomplishment = fetch_accomplishment(statistic_id, week_in_review_id)
 
         return accomplishment_response(false, ['Could not find that accomplishment']) if accomplishment.blank?
 
@@ -30,6 +27,13 @@ module Mutations
       end
 
       private
+
+      def fetch_accomplishment(statistic_id, week_in_review_id)
+        Accomplishment.find_by(
+          statistic_id: statistic_id,
+          week_in_review_id: week_in_review_id
+        )
+      end
 
       def accomplishment_response(success = true, error_messages = [])
         {

--- a/app/graphql/queries/users/me_query.rb
+++ b/app/graphql/queries/users/me_query.rb
@@ -2,7 +2,9 @@ module Queries
   module Users
     class MeQuery < Queries::BaseQuery
       description 'The Logged in user'
+
       type Types::UserType, null: true
+
       def resolve
         context[:current_user]
       end

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -87,6 +87,9 @@ type Query {
     # Enum of choices that will define the datetime attribute the statistics will be scoped to.
     datetimeType: StatisticDatetimeEnum!
 
+    # If true will return statistics for the passed datetime's week only
+    forWeek: Boolean
+
     # The GithubUser#github_id that the Statistics are scoped to.
     githubUserId: Int!
 
@@ -153,13 +156,13 @@ type Statistic {
 # During a query, defines the datetime attribute the statistics will be scoped to.
 enum StatisticDatetimeEnum {
   # Statistics closed after the passed datetime
-  CLOSED_AFTER
+  CLOSED
 
   # Statistics created after the passed datetime
-  CREATED_AFTER
+  CREATED
 
   # Statistics updated after the passed datetime
-  UPDATED_AFTER
+  UPDATED
 }
 
 # Attributes for creating or updating a Statistic.

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -227,6 +227,7 @@ type User {
   createdAt: String!
   email: String!
   firstName: String!
+  githubUser: GithubUser
   githubUsername: String!
   id: Int!
   lastName: String!

--- a/app/graphql/types/statistic_datetime_enum_type.rb
+++ b/app/graphql/types/statistic_datetime_enum_type.rb
@@ -4,19 +4,19 @@ module Types
   class StatisticDatetimeEnumType < BaseEnum
     description 'During a query, defines the datetime attribute the statistics will be scoped to.'
     value(
-      'CREATED_AFTER',
+      'CREATED',
       'Statistics created after the passed datetime',
-      value: Statistic::CREATED_AFTER
+      value: Statistic::CREATED
     )
     value(
-      'UPDATED_AFTER',
+      'UPDATED',
       'Statistics updated after the passed datetime',
-      value: Statistic::UPDATED_AFTER
+      value: Statistic::UPDATED
     )
     value(
-      'CLOSED_AFTER',
+      'CLOSED',
       'Statistics closed after the passed datetime',
-      value: Statistic::CLOSED_AFTER
+      value: Statistic::CLOSED
     )
   end
 end

--- a/app/graphql/types/user_type.rb
+++ b/app/graphql/types/user_type.rb
@@ -14,5 +14,6 @@ module Types
     field :updated_at, String, null: false
     field :access_token, Boolean, null: true
     field :org, OrganizationType, null: true
+    field :github_user, GithubUserType, null: true
   end
 end

--- a/app/javascript/components/DateOptions.js
+++ b/app/javascript/components/DateOptions.js
@@ -49,5 +49,23 @@ const DateOptions = () => {
 };
 
 const datetimeToDate = datetime => moment(datetime).format("M/D/YY");
+const dateToDayOfMonth = date => moment(date).format("dddd, M/D");
 
-export { startOfWeek, DateOptions, datetimeToDate };
+const DateToWeek = date => {
+  const startDate = moment(date).startOf("isoWeek");
+  const endDate = moment(date).endOf("isoWeek");
+
+  return (
+    <span>{`${dateToDayOfMonth(startDate)} - ${dateToDayOfMonth(
+      endDate
+    )}`}</span>
+  );
+};
+
+export {
+  startOfWeek,
+  DateOptions,
+  datetimeToDate,
+  dateToDayOfMonth,
+  DateToWeek
+};

--- a/app/javascript/components/Hello.js
+++ b/app/javascript/components/Hello.js
@@ -1,5 +1,4 @@
 import React from "react";
-import ReactDOM from "react-dom";
 
 class Hello extends React.Component {
   render() {

--- a/app/javascript/components/StatisticsCollection.js
+++ b/app/javascript/components/StatisticsCollection.js
@@ -37,11 +37,21 @@ StatisticsGroup.defaultProps = {
   showRemove: false
 };
 
-const StatisticsCollection = ({ customQuery, githubUserId, date, title }) => (
+const StatisticsCollection = ({
+  customQuery,
+  githubUserId,
+  date,
+  title,
+  forWeek = false
+}) => (
   <Query
     query={customQuery}
     skip={!githubUserId}
-    variables={{ githubUserId: parseInt(githubUserId), date: date }}
+    variables={{
+      githubUserId: parseInt(githubUserId),
+      date: date,
+      forWeek: forWeek
+    }}
   >
     {({ loading, error, data }) => {
       if (loading) return <p>Loading...</p>;

--- a/app/javascript/components/WeekInReview.js
+++ b/app/javascript/components/WeekInReview.js
@@ -1,60 +1,81 @@
 import React from "react";
 import { Query } from "react-apollo";
 import { WEEK_IN_REVIEW_QUERY } from "../queries/week_in_review_queries";
-import { StatisticsGroup } from "../components/StatisticsCollection";
+import StatisticsCollection from "./StatisticsCollection";
 import DatePicker from "react-datepicker";
 import "react-datepicker/dist/react-datepicker.css";
+import { DateToWeek } from "./DateOptions";
+import { LOAD_USER_PROFILE } from "../queries/user_queries";
+import {
+  PR_CREATED_QUERY,
+  PR_WORKED_QUERY,
+  PR_MERGED_QUERY,
+  ISSUE_CREATED_QUERY,
+  ISSUE_WORKED_QUERY,
+  ISSUE_CLOSED_QUERY
+} from "../queries/statistic_queries";
 
 const WeekInReviewStatistics = ({ date }) => (
-  <Query query={WEEK_IN_REVIEW_QUERY} variables={{ date: date }}>
+  <Query query={LOAD_USER_PROFILE}>
     {({ data, error, loading }) => {
-      if (loading) return <p>Loading...</p>;
-      if (error) return <p>Error!</p>;
-      if (data && data.weekInReview) {
-        return (
-          <div className="flex-1">
-            <h2>Current</h2>
-            <StatisticsGroup
-              statistics={data.weekInReview.issuesCreated}
-              title={`Issues | Created`}
-              showRemove={true}
-              weekInReviewId={data.weekInReview.id}
-            />
-            <StatisticsGroup
-              statistics={data.weekInReview.issuesWorked}
-              title={`Issues | Worked`}
-              showRemove={true}
-              weekInReviewId={data.weekInReview.id}
-            />
-            <StatisticsGroup
-              statistics={data.weekInReview.issuesClosed}
-              title={`Issues | Closed`}
-              showRemove={true}
-              weekInReviewId={data.weekInReview.id}
-            />
-            <StatisticsGroup
-              statistics={data.weekInReview.pullRequestsCreated}
-              title={`Pull Requests | Created`}
-              showRemove={true}
-              weekInReviewId={data.weekInReview.id}
-            />
-            <StatisticsGroup
-              statistics={data.weekInReview.pullRequestsWorked}
-              title={`Pull Requests | Worked`}
-              showRemove={true}
-              weekInReviewId={data.weekInReview.id}
-            />
-            <StatisticsGroup
-              statistics={data.weekInReview.pullRequestsMerged}
-              title={`Pull Requests | Merged`}
-              showRemove={true}
-              weekInReviewId={data.weekInReview.id}
-            />
-          </div>
-        );
-      }
+      if (loading) return <p> Loading... </p>;
+      if (error) return <p> Error! </p>;
+      const { githubId } = data.me.githubUser;
 
-      return <div />;
+      return (
+        <div>
+          <div className="flex pb-8">
+            <h3 className="pr-8"> Statistics For: </h3>{" "}
+            <div> {DateToWeek(date)} </div>
+          </div>
+          <div className="flex">
+            <h3 className="pr-8">Employee:</h3>
+            <div>{`${data.me.firstName} ${data.me.lastName}`}</div>
+          </div>
+          <StatisticsCollection
+            customQuery={ISSUE_CREATED_QUERY}
+            date={date}
+            forWeek
+            githubUserId={githubId}
+            title={`Issues | Created`}
+          />
+          <StatisticsCollection
+            customQuery={ISSUE_WORKED_QUERY}
+            date={date}
+            forWeek
+            githubUserId={githubId}
+            title={`Issues | Worked`}
+          />
+          <StatisticsCollection
+            customQuery={ISSUE_CLOSED_QUERY}
+            date={date}
+            forWeek
+            githubUserId={githubId}
+            title={`Issues | Closed`}
+          />
+          <StatisticsCollection
+            customQuery={PR_CREATED_QUERY}
+            date={date}
+            forWeek
+            githubUserId={githubId}
+            title={`Pull Requests | Created`}
+          />
+          <StatisticsCollection
+            customQuery={PR_WORKED_QUERY}
+            date={date}
+            forWeek
+            githubUserId={githubId}
+            title={`Pull Requests | Worked`}
+          />
+          <StatisticsCollection
+            customQuery={PR_MERGED_QUERY}
+            date={date}
+            forWeek
+            githubUserId={githubId}
+            title={`Pull Requests | Merged`}
+          />
+        </div>
+      );
     }}
   </Query>
 );
@@ -73,7 +94,7 @@ class WeekInReview extends React.Component {
       <div className="flex-auto">
         <h1 className="hello">Week In Review</h1>
         <div className="flex pb-8">
-          <h3 className="pr-8">Select a Week</h3>
+          <h3 className="pr-8">Select a Week:</h3>
           <DatePicker
             onChange={this.handleChange}
             maxDate={new Date()}
@@ -81,12 +102,8 @@ class WeekInReview extends React.Component {
             todayButton={`Today`}
           />
         </div>
-        <div className="flex flex-row">
+        <div>
           <WeekInReviewStatistics date={this.state.date.toISOString()} />
-          <div className="flex-1">
-            <h2>Available</h2>
-            <p>Available stats that are not in week in review will go here</p>
-          </div>
         </div>
       </div>
     );

--- a/app/javascript/components/WeekInReview.js
+++ b/app/javascript/components/WeekInReview.js
@@ -1,6 +1,5 @@
 import React from "react";
 import { Query } from "react-apollo";
-import { WEEK_IN_REVIEW_QUERY } from "../queries/week_in_review_queries";
 import StatisticsCollection from "./StatisticsCollection";
 import DatePicker from "react-datepicker";
 import "react-datepicker/dist/react-datepicker.css";

--- a/app/javascript/containers/Application.js
+++ b/app/javascript/containers/Application.js
@@ -1,7 +1,5 @@
 import React, { Component } from "react";
 
-import Hello from "../components/Hello";
-import Article from "../components/Article";
 import Navbar from "../components/Navbar";
 
 // any application wide elements can be added in this component

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -1,6 +1,6 @@
 import React from "react";
 import ReactDOM from "react-dom";
-import { BrowserRouter as Router, Route, Link } from "react-router-dom";
+import { BrowserRouter as Router } from "react-router-dom";
 import ApolloClient from "apollo-boost";
 import { ApolloProvider } from "react-apollo";
 

--- a/app/javascript/queries/statistic_queries.js
+++ b/app/javascript/queries/statistic_queries.js
@@ -25,7 +25,11 @@ const StatisticFragment = gql`
 `;
 
 const PR_CREATED_QUERY = gql`
-  query PR_CREATED_QUERY($githubUserId: Int!, $date: String!, $forWeek: Boolean!) {
+  query PR_CREATED_QUERY(
+    $githubUserId: Int!
+    $date: String!
+    $forWeek: Boolean!
+  ) {
     statistics(
       type: [PR]
       state: [OPEN, CLOSED, MERGED]
@@ -76,7 +80,11 @@ const PR_MERGED_QUERY = gql`
 `;
 
 const ISSUE_CREATED_QUERY = gql`
-  query IssueCreatedQuery($githubUserId: Int!, $date: String!, $forWeek: Boolean!) {
+  query IssueCreatedQuery(
+    $githubUserId: Int!
+    $date: String!
+    $forWeek: Boolean!
+  ) {
     statistics(
       type: [ISSUE]
       state: [OPEN, CLOSED]
@@ -93,7 +101,11 @@ const ISSUE_CREATED_QUERY = gql`
 `;
 
 const ISSUE_WORKED_QUERY = gql`
-  query IssueWorkedQuery($githubUserId: Int!, $date: String!, $forWeek: Boolean!) {
+  query IssueWorkedQuery(
+    $githubUserId: Int!
+    $date: String!
+    $forWeek: Boolean!
+  ) {
     statistics(
       type: [ISSUE]
       state: [OPEN, CLOSED]
@@ -110,7 +122,11 @@ const ISSUE_WORKED_QUERY = gql`
 `;
 
 const ISSUE_CLOSED_QUERY = gql`
-  query IssueClosedQuery($githubUserId: Int!, $date: String!, $forWeek: Boolean!) {
+  query IssueClosedQuery(
+    $githubUserId: Int!
+    $date: String!
+    $forWeek: Boolean!
+  ) {
     statistics(
       type: [ISSUE]
       state: [CLOSED]

--- a/app/javascript/queries/statistic_queries.js
+++ b/app/javascript/queries/statistic_queries.js
@@ -31,7 +31,7 @@ const PR_CREATED_QUERY = gql`
       state: [OPEN, CLOSED, MERGED]
       ownershipType: CREATED
       githubUserId: $githubUserId
-      datetimeType: CREATED_AFTER
+      datetimeType: CREATED
       datetime: $date
       forWeek: $forWeek
     ) {
@@ -48,7 +48,7 @@ const PR_WORKED_QUERY = gql`
       state: [OPEN, CLOSED, MERGED]
       ownershipType: CREATED
       githubUserId: $githubUserId
-      datetimeType: UPDATED_AFTER
+      datetimeType: UPDATED
       datetime: $date
       forWeek: $forWeek
     ) {
@@ -65,7 +65,7 @@ const PR_MERGED_QUERY = gql`
       state: [MERGED]
       ownershipType: CREATED
       githubUserId: $githubUserId
-      datetimeType: CLOSED_AFTER
+      datetimeType: CLOSED
       datetime: $date
       forWeek: $forWeek
     ) {
@@ -82,7 +82,7 @@ const ISSUE_CREATED_QUERY = gql`
       state: [OPEN, CLOSED]
       ownershipType: CREATED
       githubUserId: $githubUserId
-      datetimeType: CREATED_AFTER
+      datetimeType: CREATED
       datetime: $date
       forWeek: $forWeek
     ) {
@@ -99,7 +99,7 @@ const ISSUE_WORKED_QUERY = gql`
       state: [OPEN, CLOSED]
       ownershipType: ASSIGNED
       githubUserId: $githubUserId
-      datetimeType: UPDATED_AFTER
+      datetimeType: UPDATED
       datetime: $date
       forWeek: $forWeek
     ) {
@@ -116,7 +116,7 @@ const ISSUE_CLOSED_QUERY = gql`
       state: [CLOSED]
       ownershipType: ASSIGNED
       githubUserId: $githubUserId
-      datetimeType: CLOSED_AFTER
+      datetimeType: CLOSED
       datetime: $date
       forWeek: $forWeek
     ) {

--- a/app/javascript/queries/statistic_queries.js
+++ b/app/javascript/queries/statistic_queries.js
@@ -25,7 +25,7 @@ const StatisticFragment = gql`
 `;
 
 const PR_CREATED_QUERY = gql`
-  query PR_CREATED_QUERY($githubUserId: Int!, $date: String!) {
+  query PR_CREATED_QUERY($githubUserId: Int!, $date: String!, $forWeek: Boolean!) {
     statistics(
       type: [PR]
       state: [OPEN, CLOSED, MERGED]
@@ -33,6 +33,7 @@ const PR_CREATED_QUERY = gql`
       githubUserId: $githubUserId
       datetimeType: CREATED_AFTER
       datetime: $date
+      forWeek: $forWeek
     ) {
       ...StatisticQueryFields
     }
@@ -41,7 +42,7 @@ const PR_CREATED_QUERY = gql`
 `;
 
 const PR_WORKED_QUERY = gql`
-  query PrWorkedQuery($githubUserId: Int!, $date: String!) {
+  query PrWorkedQuery($githubUserId: Int!, $date: String!, $forWeek: Boolean!) {
     statistics(
       type: [PR]
       state: [OPEN, CLOSED, MERGED]
@@ -49,6 +50,7 @@ const PR_WORKED_QUERY = gql`
       githubUserId: $githubUserId
       datetimeType: UPDATED_AFTER
       datetime: $date
+      forWeek: $forWeek
     ) {
       ...StatisticQueryFields
     }
@@ -57,7 +59,7 @@ const PR_WORKED_QUERY = gql`
 `;
 
 const PR_MERGED_QUERY = gql`
-  query PrMergedQuery($githubUserId: Int!, $date: String!) {
+  query PrMergedQuery($githubUserId: Int!, $date: String!, $forWeek: Boolean!) {
     statistics(
       type: [PR]
       state: [MERGED]
@@ -65,6 +67,7 @@ const PR_MERGED_QUERY = gql`
       githubUserId: $githubUserId
       datetimeType: CLOSED_AFTER
       datetime: $date
+      forWeek: $forWeek
     ) {
       ...StatisticQueryFields
     }
@@ -73,7 +76,7 @@ const PR_MERGED_QUERY = gql`
 `;
 
 const ISSUE_CREATED_QUERY = gql`
-  query IssueCreatedQuery($githubUserId: Int!, $date: String!) {
+  query IssueCreatedQuery($githubUserId: Int!, $date: String!, $forWeek: Boolean!) {
     statistics(
       type: [ISSUE]
       state: [OPEN, CLOSED]
@@ -81,6 +84,7 @@ const ISSUE_CREATED_QUERY = gql`
       githubUserId: $githubUserId
       datetimeType: CREATED_AFTER
       datetime: $date
+      forWeek: $forWeek
     ) {
       ...StatisticQueryFields
     }
@@ -89,7 +93,7 @@ const ISSUE_CREATED_QUERY = gql`
 `;
 
 const ISSUE_WORKED_QUERY = gql`
-  query IssueWorkedQuery($githubUserId: Int!, $date: String!) {
+  query IssueWorkedQuery($githubUserId: Int!, $date: String!, $forWeek: Boolean!) {
     statistics(
       type: [ISSUE]
       state: [OPEN, CLOSED]
@@ -97,6 +101,7 @@ const ISSUE_WORKED_QUERY = gql`
       githubUserId: $githubUserId
       datetimeType: UPDATED_AFTER
       datetime: $date
+      forWeek: $forWeek
     ) {
       ...StatisticQueryFields
     }
@@ -105,7 +110,7 @@ const ISSUE_WORKED_QUERY = gql`
 `;
 
 const ISSUE_CLOSED_QUERY = gql`
-  query IssueClosedQuery($githubUserId: Int!, $date: String!) {
+  query IssueClosedQuery($githubUserId: Int!, $date: String!, $forWeek: Boolean!) {
     statistics(
       type: [ISSUE]
       state: [CLOSED]
@@ -113,6 +118,7 @@ const ISSUE_CLOSED_QUERY = gql`
       githubUserId: $githubUserId
       datetimeType: CLOSED_AFTER
       datetime: $date
+      forWeek: $forWeek
     ) {
       ...StatisticQueryFields
     }

--- a/app/javascript/queries/user_queries.js
+++ b/app/javascript/queries/user_queries.js
@@ -4,9 +4,17 @@ const LOAD_USER_PROFILE = gql`
     me {
       id
       accessToken
+      firstName
+      lastName
       githubUsername
       org {
         name
+      }
+      githubUser {
+        apiUrl
+        avatarUrl
+        githubId
+        htmlUrl
       }
     }
   }

--- a/app/javascript/queries/week_in_review_queries.js
+++ b/app/javascript/queries/week_in_review_queries.js
@@ -1,5 +1,5 @@
 import gql from "graphql-tag";
-import { StatisticFragment } from "./statistic_queries"
+import { StatisticFragment } from "./statistic_queries";
 
 const WEEK_IN_REVIEW_QUERY = gql`
   query WeekInReviewQuery($date: String!) {

--- a/app/javascript/routes.js
+++ b/app/javascript/routes.js
@@ -1,7 +1,6 @@
 import React from "react";
-import { Route, Link, Switch } from "react-router-dom";
+import { Route, Switch } from "react-router-dom";
 
-import Article from "./components/Article";
 import Goodbye from "./components/Goodbye";
 import Hello from "./components/Hello";
 import NotFoundPage from "./components/NotFoundPage";

--- a/app/models/statistic.rb
+++ b/app/models/statistic.rb
@@ -25,9 +25,7 @@ class Statistic < ApplicationRecord
   CREATED = 'created'
 
   # datetime_types
-  CREATED_AFTER = 'created_after'
-  UPDATED_AFTER = 'updated_after'
-  CLOSED_AFTER  = 'closed_after'
+  UPDATED = 'updated'
 
   has_and_belongs_to_many :github_users
   has_many :accomplishments, dependent: :destroy

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -44,4 +44,10 @@ class User < ApplicationRecord
   def access_token
     personal_access_token.present?
   end
+
+  def github_user
+    return unless github_username
+
+    GithubUser.find_by(github_login: github_username)
+  end
 end

--- a/app/services/week_in_reviews/boundries.rb
+++ b/app/services/week_in_reviews/boundries.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module WeekInReviews
+  class Boundries
+    attr_reader :date, :start_date, :end_date, :start_time, :end_time
+
+    # @param date [String] A date in the 'YYYY-MM-DD' format.
+    #   Will accept a datetime string, as well.
+    #
+    def initialize(date)
+      @date = validate!(date)
+      @start_date = determine_start_date
+      @end_date = determine_end_date
+      @start_time = determine_start_time
+      @end_time = determine_end_time
+    end
+
+    private
+
+    def validate!(date)
+      raise WeekInReviews::Error, 'Date must be a string' if date.class != String
+      raise WeekInReviews::Error, 'Date must be a string' if Date.parse(date).class != Date
+
+      Date.parse(date)
+    end
+
+    def determine_start_date
+      date.beginning_of_week
+    end
+
+    def determine_end_date
+      date.end_of_week
+    end
+
+    def determine_start_time
+      start_date.beginning_of_day.iso8601
+    end
+
+    def determine_end_time
+      end_date.end_of_day.iso8601
+    end
+  end
+end

--- a/app/services/week_in_reviews/boundries.rb
+++ b/app/services/week_in_reviews/boundries.rb
@@ -1,6 +1,13 @@
 # frozen_string_literal: true
 
 module WeekInReviews
+  # This class takes in a date, and determines the week that the date falls in.
+  # It then creates methods for that week's boundries, specifically its:
+  #   - start_date
+  #   - end_date
+  #   - start_time (beginning of start_date)
+  #   - end_time (end of end_date)
+  #
   class Boundries
     attr_reader :date, :start_date, :end_date, :start_time, :end_time
 

--- a/app/services/week_in_reviews/builder.rb
+++ b/app/services/week_in_reviews/builder.rb
@@ -2,7 +2,7 @@
 
 module WeekInReviews
   class Builder
-    attr_reader :user, :date, :start_date, :end_date, :filter, :week_in_review
+    attr_reader :user, :filter, :boundries, :week_in_review
 
     # @param user [User] A User record
     # @param date [String] A date that will define the WeekInReview's
@@ -11,10 +11,8 @@ module WeekInReviews
     #
     def initialize(user, date)
       @user = user
-      @date = validate_date!(date)
-      @start_date = determine_start_date
-      @end_date = determine_end_date
-      @filter = WeekInReviews::Filter.new(validated_github_id!, start_time, end_time)
+      @boundries = WeekInReviews::Boundries.new(date)
+      @filter = WeekInReviews::Filter.new(validated_github_id!, date)
     end
 
     # Creates a WeekInReview record and all of the week's Accomplishments,
@@ -30,21 +28,6 @@ module WeekInReviews
 
     private
 
-    def validate_date!(date)
-      raise WeekInReviews::Error, 'Date must be a string' if date.class != String
-      raise WeekInReviews::Error, 'Date must be a string' if Date.parse(date).class != Date
-
-      Date.parse(date)
-    end
-
-    def determine_start_date
-      date.beginning_of_week
-    end
-
-    def determine_end_date
-      date.end_of_week
-    end
-
     def validated_github_id!
       github_user = GithubUser.find_by(user_id: user.id)
 
@@ -53,19 +36,11 @@ module WeekInReviews
       github_user.github_id
     end
 
-    def start_time
-      start_date.beginning_of_day.iso8601
-    end
-
-    def end_time
-      end_date.end_of_day.iso8601
-    end
-
     def create_week_in_review!
       @week_in_review = WeekInReview.create!(
         user: user,
-        start_date: start_date,
-        end_date: end_date
+        start_date: boundries.start_date,
+        end_date: boundries.end_date
       )
     end
 

--- a/app/services/week_in_reviews/filter.rb
+++ b/app/services/week_in_reviews/filter.rb
@@ -2,12 +2,13 @@
 
 module WeekInReviews
   class Filter
-    attr_reader :github_user_id, :start_time, :end_time
+    attr_reader :github_user_id, :boundries, :start_time, :end_time
 
-    def initialize(github_user_id, start_time, end_time)
+    def initialize(github_user_id, date)
       @github_user_id = github_user_id
-      @start_time = validate_time!(start_time)
-      @end_time = validate_time!(end_time)
+      @boundries = WeekInReviews::Boundries.new(date)
+      @start_time = boundries.start_time
+      @end_time = boundries.end_time
     end
 
     def created_issues
@@ -62,15 +63,6 @@ module WeekInReviews
         .created_by(github_user_id)
         .closed_after(start_time)
         .closed_before(end_time)
-    end
-
-    private
-
-    def validate_time!(time)
-      raise WeekInReviews::Error, 'Time must be a string' if time.class != String
-      raise WeekInReviews::Error, 'Time must be a string' if Time.parse(time).class != Time
-
-      Time.parse(time).iso8601
     end
   end
 end

--- a/spec/graphql/mutations/accomplishments/delete_accomplishment_mutation_spec.rb
+++ b/spec/graphql/mutations/accomplishments/delete_accomplishment_mutation_spec.rb
@@ -49,9 +49,9 @@ RSpec.describe Mutations::Accomplishments::DeleteAccomplishmentMutation do
 
   it 'yields the expected response shape and values' do
     expected_response = {
-      "deleteAccomplishment" => {
-        "success" => true,
-        "errors" => []
+      'deleteAccomplishment' => {
+        'success' => true,
+        'errors' => []
       }
     }
 

--- a/spec/graphql/queries/statistics/statistics_query_spec.rb
+++ b/spec/graphql/queries/statistics/statistics_query_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Queries::Statistics::StatisticsQuery do
             githubUserId: #{github_user.github_id},
             type: [ISSUE],
             state: [OPEN],
-            datetimeType: CREATED_AFTER,
+            datetimeType: CREATED,
             datetime: "#{january_1_2018}"
           ) {
             source
@@ -73,7 +73,7 @@ RSpec.describe Queries::Statistics::StatisticsQuery do
             githubUserId: #{github_user.github_id},
             type: [ISSUE],
             state: [OPEN, CLOSED],
-            datetimeType: CREATED_AFTER,
+            datetimeType: CREATED,
             datetime: "#{january_1_2018}"
           ) {
             sourceType
@@ -118,7 +118,7 @@ RSpec.describe Queries::Statistics::StatisticsQuery do
             githubUserId: #{github_user.github_id},
             type: [ISSUE],
             state: [OPEN, CLOSED],
-            datetimeType: UPDATED_AFTER,
+            datetimeType: UPDATED,
             datetime: "#{january_1_2018}"
           ) {
             sourceType
@@ -163,7 +163,7 @@ RSpec.describe Queries::Statistics::StatisticsQuery do
             githubUserId: #{github_user.github_id},
             type: [ISSUE],
             state: [CLOSED],
-            datetimeType: CLOSED_AFTER,
+            datetimeType: CLOSED,
             datetime: "#{january_1_2018}"
           ) {
             sourceType
@@ -208,7 +208,7 @@ RSpec.describe Queries::Statistics::StatisticsQuery do
             githubUserId: #{github_user.github_id},
             type: [PR],
             state: [OPEN, CLOSED, MERGED],
-            datetimeType: CREATED_AFTER,
+            datetimeType: CREATED,
             datetime: "#{january_1_2018}"
           ) {
             sourceType
@@ -253,7 +253,7 @@ RSpec.describe Queries::Statistics::StatisticsQuery do
             githubUserId: #{github_user.github_id},
             type: [PR],
             state: [OPEN, CLOSED, MERGED],
-            datetimeType: UPDATED_AFTER,
+            datetimeType: UPDATED,
             datetime: "#{january_1_2018}"
           ) {
             sourceType
@@ -298,7 +298,7 @@ RSpec.describe Queries::Statistics::StatisticsQuery do
             githubUserId: #{github_user.github_id},
             type: [PR],
             state: [MERGED],
-            datetimeType: CLOSED_AFTER,
+            datetimeType: CLOSED,
             datetime: "#{january_1_2018}"
           ) {
             sourceType

--- a/spec/services/week_in_reviews/boundries_spec.rb
+++ b/spec/services/week_in_reviews/boundries_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe WeekInReviews::Boundries do
+  let(:date) { '2018-10-11' }
+  let(:boundries) { WeekInReviews::Boundries.new(date) }
+
+  describe '#initialize' do
+    it 'raises an error if an invalid date format is passed' do
+      invalid_date = Date.today
+
+      expect { WeekInReviews::Boundries.new(invalid_date) }.to raise_error(
+        WeekInReviews::Error,
+        'Date must be a string'
+      )
+    end
+  end
+
+  describe '#start_date' do
+    it 'sets the start_date to the Monday of the passed week', :aggregate_failures do
+      expect(boundries.start_date.monday?).to eq true
+      expect(boundries.start_date.to_s).to eq '2018-10-08'
+    end
+  end
+
+  describe '#end_date' do
+    it 'sets the end_date to the Sunday of the passed week', :aggregate_failures do
+      expect(boundries.end_date.sunday?).to eq true
+      expect(boundries.end_date.to_s).to eq '2018-10-14'
+    end
+  end
+
+  describe '#start_time' do
+    it 'sets the start_time to the beginning of Monday of the passed week' do
+      expect(boundries.start_time).to eq '2018-10-08T00:00:00Z'
+    end
+
+    it 'is an iso8601 string', :aggregate_failures do
+      expect(boundries.start_time.class).to eq String
+      expect(boundries.start_time).to include 'T00:00:00Z'
+    end
+  end
+
+  describe '#end_time' do
+    it 'sets the end_time to the end of Sunday of the passed week' do
+      expect(boundries.end_time).to eq '2018-10-14T23:59:59Z'
+    end
+
+    it 'is an iso8601 string', :aggregate_failures do
+      expect(boundries.end_time.class).to eq String
+      expect(boundries.end_time).to include 'T23:59:59Z'
+    end
+  end
+end

--- a/spec/services/week_in_reviews/builder_spec.rb
+++ b/spec/services/week_in_reviews/builder_spec.rb
@@ -8,16 +8,7 @@ RSpec.describe WeekInReviews::Builder do
   let(:github_user) { create :github_user, user_id: user.id }
   let(:hub_id) { github_user.github_id }
 
-  describe '.initialize' do
-    it 'raises an error if an invalid date format is passed' do
-      invalid_date = Date.today
-
-      expect { WeekInReviews::Builder.new(user, invalid_date) }.to raise_error(
-        WeekInReviews::Error,
-        'Date must be a string'
-      )
-    end
-
+  describe '#initialize' do
     it 'raises an error if the passed User does not have a GithubUser record' do
       invalid_user = create :user
 

--- a/spec/services/week_in_reviews/filter_spec.rb
+++ b/spec/services/week_in_reviews/filter_spec.rb
@@ -3,12 +3,13 @@
 require 'rails_helper'
 
 RSpec.describe WeekInReviews::Filter do
+  let(:date) { '2018-10-11' }
   let(:start_time) { '2018-10-08T00:00:00Z' }
   let(:end_time) { '2018-10-14T23:59:59Z' }
   let(:github_user) { create :github_user }
   let(:hub_id) { github_user.github_id }
   let(:non_user) { create :github_user }
-  let(:filter) { WeekInReviews::Filter.new(hub_id, start_time, end_time) }
+  let(:filter) { WeekInReviews::Filter.new(hub_id, date) }
 
   before do
     create :statistic, :open_pr, source_created_by: hub_id
@@ -22,23 +23,8 @@ RSpec.describe WeekInReviews::Filter do
     create :statistic, assignees: [non_user.github_id]
   end
 
-  describe '.initialize' do
-    it 'raises an error if an invalid time format is passed' do
-      invalid_time = Time.now
-
-      expect { WeekInReviews::Filter.new(hub_id, invalid_time, end_time) }.to raise_error(
-        WeekInReviews::Error,
-        'Time must be a string'
-      )
-    end
-  end
-
   describe '#created_issues' do
     let(:statistics) { filter.created_issues }
-
-    it 'finds and returns the expected number of Statistics' do
-      expect(statistics.count).to eq 2
-    end
 
     it 'only returns issues' do
       expect(statistics.pluck(:source_type).uniq).to eq [Statistic::ISSUE]


### PR DESCRIPTION
## Background
This PR makes the Week in Review page dynamic for the selected week.

For the current user, the Week In Review page will now display:

- one week’s worth of statistics
- statistics dynamically, meaning it updates itself as the week progress, pulling in any new updates in the database
- the statistics for the selected week only
- the week’s start and end dates, that the statistics fall within
- the associated employee, meaning the current user

It does not create a `WeekInReview` db record, and the associated `Accomplishment` db records, as it used to.

This will now happen as part of a workflow where the user decided to “begin the week in review submittal process”, in upcoming stories.

## Issue Resolved
<!-- Keeping the format 'Issue #123' will automatically link & close the associated issue when this PR is merged -->
Issue #87 
 
## Definition of Done
 
- [x] when user visits WIR page, it presents the stats that fall within the week of the selected date
- [x] dynamically updates with stats that are present in the database
- [x] displays the start and end dates of the selected week
- [x] displays the employee (current user)
- [x] displays one week's worth of stats 

## Preview

![2018-12-23 10 50 26](https://user-images.githubusercontent.com/7482329/50386284-ef401880-06a0-11e9-987c-18d1158e4498.gif)

