### PR TITLE
88 week in review submittal page

### DIFF
--- a/app/javascript/components/DateOptions.js
+++ b/app/javascript/components/DateOptions.js
@@ -49,6 +49,7 @@ const DateOptions = () => {
 };
 
 const datetimeToDate = datetime => moment(datetime).format("M/D/YY");
+const datetimeToParams = datetime => moment(datetime).format("YYYY-MM-DD");
 const dateToDayOfMonth = date => moment(date).format("dddd, M/D");
 
 const DateToWeek = date => {
@@ -67,5 +68,6 @@ export {
   DateOptions,
   datetimeToDate,
   dateToDayOfMonth,
-  DateToWeek
+  DateToWeek,
+  datetimeToParams
 };

--- a/app/javascript/components/Profile.js
+++ b/app/javascript/components/Profile.js
@@ -6,6 +6,7 @@ import {
   UPDATE_GITHUB_ORG
 } from "../mutations/user_mutations";
 import { LOAD_USER_PROFILE } from "../queries/user_queries";
+import { buttonClasses } from "../css/sharedTailwindClasses";
 
 const MOCK_ORGS = [
   {
@@ -84,10 +85,7 @@ const UpdateAccessToken = props => {
                   placeholder="Personal Access Token"
                   aria-label="Access Token"
                 />
-                <button
-                  className="flex-no-shrink bg-teal hover:bg-teal-dark border-teal hover:border-teal-dark text-sm border-4 text-white py-1 px-2 rounded"
-                  type="submit"
-                >
+                <button className={buttonClasses} type="submit">
                   Update Token
                 </button>
               </div>
@@ -136,10 +134,7 @@ const UpdateGithubUsername = props => {
                   placeholder={props.githubUsername}
                   aria-label="Github Username"
                 />
-                <button
-                  className="flex-no-shrink bg-teal hover:bg-teal-dark border-teal hover:border-teal-dark text-sm border-4 text-white py-1 px-2 rounded"
-                  type="submit"
-                >
+                <button className={buttonClasses} type="submit">
                   Update Github Username
                 </button>
               </div>
@@ -198,10 +193,7 @@ const UpdateGithubOrg = props => {
                     <path d="M9.293 12.95l.707.707L15.657 8l-1.414-1.414L10 10.828 5.757 6.586 4.343 8z" />
                   </svg>
                 </div>
-                <button
-                  className="flex-no-shrink bg-teal hover:bg-teal-dark border-teal hover:border-teal-dark text-sm border-4 text-white py-1 px-2 rounded"
-                  type="submit"
-                >
+                <button className={buttonClasses} type="submit">
                   Update Github Organization
                 </button>
               </div>

--- a/app/javascript/components/Statistic.js
+++ b/app/javascript/components/Statistic.js
@@ -1,4 +1,5 @@
 import React from "react";
+import Swal from "sweetalert2";
 import { Mutation } from "react-apollo";
 import { DELETE_ACCOMPLISHMENT_MUTATION } from "../mutations/accomplishment_mutations";
 
@@ -12,7 +13,7 @@ class Statistic extends React.Component {
   };
 
   render() {
-    if (this.state.deleted) return <div>Poof gone!</div>;
+    if (this.state.deleted) return <span />;
     return (
       <div className="border border-grey-light rounded text-grey-darkest p-3 m-1 ml-0 max-w-sm">
         {this.props.showRemove ? (
@@ -28,11 +29,27 @@ class Statistic extends React.Component {
               return (
                 <span
                   className="float-right hover:text-teal-light no-underline cursor-pointer"
-                  onClick={e => {
-                    if (window.confirm(`Remove "${this.props.title}"?`)) {
-                      deleteAccomplishment();
-                      this.hideStat();
-                    }
+                  onClick={() => {
+                    Swal({
+                      type: "warning",
+                      title: "Remove",
+                      html: `Remove <span class="italic">"${
+                        this.props.title
+                      }"</span>?`,
+                      showCancelButton: true
+                    }).then(saidOk => {
+                      if (saidOk.value) {
+                        deleteAccomplishment();
+                        this.hideStat();
+                        Swal({
+                          type: "success",
+                          title: "Removed!",
+                          html: `Removed <span class="italic">"${
+                            this.props.title
+                          }"</span>`
+                        });
+                      }
+                    });
                   }}
                   title={`Remove`}
                 >

--- a/app/javascript/components/WeekInReview.js
+++ b/app/javascript/components/WeekInReview.js
@@ -1,9 +1,11 @@
 import React from "react";
 import { Query } from "react-apollo";
-import StatisticsCollection from "./StatisticsCollection";
+import Swal from "sweetalert2";
 import DatePicker from "react-datepicker";
 import "react-datepicker/dist/react-datepicker.css";
-import { DateToWeek } from "./DateOptions";
+
+import StatisticsCollection from "./StatisticsCollection";
+import { DateToWeek, datetimeToParams, datetimeToDate } from "./DateOptions";
 import { LOAD_USER_PROFILE } from "../queries/user_queries";
 import {
   PR_CREATED_QUERY,
@@ -13,6 +15,7 @@ import {
   ISSUE_WORKED_QUERY,
   ISSUE_CLOSED_QUERY
 } from "../queries/statistic_queries";
+import { buttonClasses } from "../css/sharedTailwindClasses";
 
 const WeekInReviewStatistics = ({ date }) => (
   <Query query={LOAD_USER_PROFILE}>
@@ -88,10 +91,34 @@ class WeekInReview extends React.Component {
     this.setState({ date: e });
   };
 
+  handleSubmit = () => {
+    Swal({
+      type: "warning",
+      title: "Week in Review",
+      text: `Begin submittal process for week of ${datetimeToDate(
+        this.state.date
+      )}?`,
+      showCancelButton: true
+    }).then(saidOk => {
+      if (saidOk.value) {
+        this.props.history.push(
+          `/week-in-review-submittal?date=${datetimeToParams(this.state.date)}`
+        );
+      }
+    });
+  };
+
   render() {
     return (
       <div className="flex-auto">
         <h1 className="hello">Week In Review</h1>
+        <button
+          className={`${buttonClasses} float-right `}
+          onClick={this.handleSubmit}
+          type="submit"
+        >
+          Submit Week In Review
+        </button>
         <div className="flex pb-8">
           <h3 className="pr-8">Select a Week:</h3>
           <DatePicker

--- a/app/javascript/components/WeekInReviewSubmittal.js
+++ b/app/javascript/components/WeekInReviewSubmittal.js
@@ -1,0 +1,195 @@
+import React from "react";
+import { Query } from "react-apollo";
+import Textarea from "react-textarea-autosize";
+import Swal from "sweetalert2"; // https://sweetalert2.github.io/
+
+import { WEEK_IN_REVIEW_QUERY } from "../queries/week_in_review_queries";
+import { StatisticsGroup } from "../components/StatisticsCollection";
+import { DateToWeek } from "./DateOptions";
+import { buttonClasses } from "../css/sharedTailwindClasses";
+
+const WeekInReviewStatistics = ({ date }) => (
+  <Query
+    query={WEEK_IN_REVIEW_QUERY}
+    variables={{
+      date: date
+    }}
+  >
+    {({ data, error, loading }) => {
+      if (loading) {
+        return (
+          <div className="text-grey-darkest p-3 ml-0 w-1/2">Loading...</div>
+        );
+      }
+      if (error) {
+        return <div className="text-grey-darkest p-3 ml-0 w-1/2">Error!</div>;
+      }
+      if (data && data.weekInReview) {
+        return (
+          <div className="flex-1 pb-8">
+            <div className="flex">
+              <h3 className="pr-8"> Week in Review for: </h3>
+              <div> {DateToWeek(date)} </div>
+            </div>
+            <StatisticsGroup
+              statistics={data.weekInReview.issuesCreated}
+              title={`Issues | Created`}
+              showRemove={true}
+              weekInReviewId={data.weekInReview.id}
+            />
+            <StatisticsGroup
+              statistics={data.weekInReview.issuesWorked}
+              title={`Issues | Worked`}
+              showRemove={true}
+              weekInReviewId={data.weekInReview.id}
+            />
+            <StatisticsGroup
+              statistics={data.weekInReview.issuesClosed}
+              title={`Issues | Closed`}
+              showRemove={true}
+              weekInReviewId={data.weekInReview.id}
+            />
+            <StatisticsGroup
+              statistics={data.weekInReview.pullRequestsCreated}
+              title={`Pull Requests | Created`}
+              showRemove={true}
+              weekInReviewId={data.weekInReview.id}
+            />
+            <StatisticsGroup
+              statistics={data.weekInReview.pullRequestsWorked}
+              title={`Pull Requests | Worked`}
+              showRemove={true}
+              weekInReviewId={data.weekInReview.id}
+            />
+            <StatisticsGroup
+              statistics={data.weekInReview.pullRequestsMerged}
+              title={`Pull Requests | Merged`}
+              showRemove={true}
+              weekInReviewId={data.weekInReview.id}
+            />
+          </div>
+        );
+      }
+
+      return <div />;
+    }}
+  </Query>
+);
+
+const getDate = urlParams => {
+  const params = urlParams.split("?date=");
+  const date = params[params.length - 1];
+
+  return date;
+};
+
+const labelClasses =
+  "block uppercase tracking-wide text-grey-darker text-xs font-bold mb-2";
+const inputClasses =
+  "appearance-none block bg-grey-lighter text-grey-darker border border-grey-light rounded py-3 px-4 mb-3 leading-tight focus:outline-none focus:bg-white";
+const textAreaClasses = `h-48 w-full ${inputClasses}`;
+
+class WeekInReviewSubmittal extends React.Component {
+  state = {
+    date: getDate(this.props.location.search)
+  };
+
+  handleAddIssuePrSubmit = e => {
+    e.preventDefault();
+  };
+
+  handleCommentsSubmit = e => {
+    e.preventDefault();
+  };
+
+  handleWeekInReviewSubmit = e => {
+    e.preventDefault();
+    Swal({
+      type: "warning",
+      title: "Submit Week in Review?",
+      showCancelButton: true
+    }).then(saidOk => {
+      if (saidOk.value) {
+        Swal("Submitted!", "Your Week in Review has been submitted", "success");
+      }
+    });
+  };
+
+  render() {
+    return (
+      <div className="flex-auto">
+        <h1 className="hello"> Week In Review </h1>
+        <div className="flex flex-row flex-wrap">
+          <WeekInReviewStatistics date={this.state.date} />
+          <div className="flex-1 pb-8">
+            <h3 className="pb-8">Add Issue/PR</h3>
+            <form className="w-full" onSubmit={this.handleAddIssuePrSubmit}>
+              <div className="flex flex-row pb-8">
+                <input
+                  className={`${inputClasses} flex-grow mr-4`}
+                  type="text"
+                  value={this.state.value}
+                  onChange={this.handleChange}
+                  placeholder={`Paste GitHub URL of issue or pull request`}
+                />
+                <button className={`${buttonClasses} h-12`}> Add </button>
+              </div>
+            </form>
+            <h3 className="pb-8">Comments</h3>
+            <div className="flex pb-8">
+              <form className="w-full" onSubmit={this.handleCommentsSubmit}>
+                <label className={labelClasses}>How did your week go?</label>
+                <Textarea
+                  className={textAreaClasses}
+                  minRows={3}
+                  name="week_go"
+                  onChange={this.handleChange}
+                  value={this.state.value}
+                />
+                <label className={labelClasses}>Any concerns?</label>
+                <Textarea
+                  className={textAreaClasses}
+                  minRows={3}
+                  name="concerns"
+                  onChange={this.handleChange}
+                  value={this.state.value}
+                />
+                <label className={labelClasses}>
+                  How is your Oddball team?
+                </label>
+                <Textarea
+                  className={textAreaClasses}
+                  minRows={3}
+                  name="oddball_team"
+                  onChange={this.handleChange}
+                  value={this.state.value}
+                />
+                <label className={labelClasses}>
+                  How is your Project team?
+                </label>
+                <Textarea
+                  className={textAreaClasses}
+                  minRows={3}
+                  name="project_team"
+                  onChange={this.handleChange}
+                  value={this.state.value}
+                />
+                <button className={`${buttonClasses} float-right`}>
+                  Save Comments
+                </button>
+              </form>
+            </div>
+            <button
+              className={`bg-blue hover:bg-blue-dark text-white font-bold py-2 px-4 rounded w-full`}
+              onClick={this.handleWeekInReviewSubmit}
+            >
+              Submit Week In Review
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+export default WeekInReviewSubmittal;

--- a/app/javascript/css/sharedTailwindClasses.js
+++ b/app/javascript/css/sharedTailwindClasses.js
@@ -1,0 +1,4 @@
+const buttonClasses =
+  "flex-no-shrink bg-teal hover:bg-teal-dark border-teal hover:border-teal-dark text-sm border-4 text-white py-1 px-2 rounded";
+
+export { buttonClasses };

--- a/app/javascript/routes.js
+++ b/app/javascript/routes.js
@@ -7,6 +7,7 @@ import NotFoundPage from "./components/NotFoundPage";
 import Profile from "./components/Profile";
 import Statistics from "./components/Statistics";
 import WeekInReview from "./components/WeekInReview";
+import WeekInReviewSubmittal from "./components/WeekInReviewSubmittal";
 
 const routes = (
   <Switch>
@@ -15,6 +16,7 @@ const routes = (
     <Route path="/profile" component={Profile} />
     <Route path="/statistics" component={Statistics} />
     <Route path="/week-in-review" component={WeekInReview} />
+    <Route path="/week-in-review-submittal" component={WeekInReviewSubmittal} />
     <Route component={NotFoundPage} />
   </Switch>
 );

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "react-dom": "^16.5.2",
     "react-router-dom": "^4.3.1",
     "react_ujs": "^2.4.4",
+    "sweetalert2": "^7.33.1",
     "tailwindcss": "^0.6.6",
     "yarn": "^1.10.1"
   },

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "react-datepicker": "^2.0.0",
     "react-dom": "^16.5.2",
     "react-router-dom": "^4.3.1",
+    "react-textarea-autosize": "^7.1.0",
     "react_ujs": "^2.4.4",
     "sweetalert2": "^7.33.1",
     "tailwindcss": "^0.6.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -628,6 +628,12 @@
   dependencies:
     regenerator-runtime "^0.12.0"
 
+"@babel/runtime@^7.1.2":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.2.0.tgz#b03e42eeddf5898e00646e4c840fa07ba8dcad7f"
+  dependencies:
+    regenerator-runtime "^0.12.0"
+
 "@babel/template@7.0.0-beta.44":
   version "7.0.0-beta.44"
   resolved "http://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.44.tgz#f8832f4fdcee5d59bf515e595fc5106c529b394f"
@@ -5610,6 +5616,13 @@ react-router@^4.3.1:
     path-to-regexp "^1.7.0"
     prop-types "^15.6.1"
     warning "^4.0.1"
+
+react-textarea-autosize@^7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/react-textarea-autosize/-/react-textarea-autosize-7.1.0.tgz#3132cb77e65d94417558d37c0bfe415a5afd3445"
+  dependencies:
+    "@babel/runtime" "^7.1.2"
+    prop-types "^15.6.0"
 
 react@^16.5.2:
   version "16.5.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6447,6 +6447,10 @@ svgo@^1.0.0:
     unquote "~1.1.1"
     util.promisify "~1.0.0"
 
+sweetalert2@^7.33.1:
+  version "7.33.1"
+  resolved "https://registry.yarnpkg.com/sweetalert2/-/sweetalert2-7.33.1.tgz#7e3534d2c2962f875f419cfea5d75ee526d65cd4"
+
 symbol-observable@^1.0.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"


### PR DESCRIPTION
## Background
When the user is ready, they'll need a page to submit their week's accomplishments. 

## Issue Resolved
<!-- Keeping the format 'Issue #123' will automatically link & close the associated issue when this PR is merged -->
Issue #88 
 
## Definition of Done
 
- [x] 'submit' button from WIR page bringing them into a page to begin the submittal process, with confirmation
- [x] entering the page creates a `WeekInReview` db record and associated `Accomplishment` records; if a WIR already exists, uses that one
- [x] new page displays all of their current stats/accomplishments for the selected week
- [x] all the stats have a 'remove' icon
- [x] clicking remove removes the stat for their week, with a confirmation
- [x] page carves out a comments section (implementation to be completed in an upcoming issue)
- [x] text areas auto-resize
- [x] page carves out an 'add stat' section (implementation to be completed in an upcoming issue)

## Preview

![2018-12-24 13 12 39](https://user-images.githubusercontent.com/7482329/50406187-f4bf6080-077d-11e9-8436-4550ddf88e73.gif)

