### PR TITLE
Create Accomplishment records for newly added Statistic

### DIFF
--- a/app/models/accomplishment.rb
+++ b/app/models/accomplishment.rb
@@ -19,51 +19,51 @@ class Accomplishment < ApplicationRecord
   scope :issues, -> { where(type: Statistic::ISSUE) }
   scope :pull_requests, -> { where(type: Statistic::PR) }
 
-  def self.create_created_issue!(week_in_review, statistic, user)
+  def self.create_created_issue!(week_in_review_id, statistic_id, user_id)
     issues.created.create!(
-      week_in_review: week_in_review,
-      statistic: statistic,
-      user: user
+      week_in_review_id: week_in_review_id,
+      statistic_id: statistic_id,
+      user_id: user_id
     )
   end
 
-  def self.create_worked_issue!(week_in_review, statistic, user)
+  def self.create_worked_issue!(week_in_review_id, statistic_id, user_id)
     issues.worked.create!(
-      week_in_review: week_in_review,
-      statistic: statistic,
-      user: user
+      week_in_review_id: week_in_review_id,
+      statistic_id: statistic_id,
+      user_id: user_id
     )
   end
 
-  def self.create_closed_issue!(week_in_review, statistic, user)
+  def self.create_closed_issue!(week_in_review_id, statistic_id, user_id)
     issues.closed.create!(
-      week_in_review: week_in_review,
-      statistic: statistic,
-      user: user
+      week_in_review_id: week_in_review_id,
+      statistic_id: statistic_id,
+      user_id: user_id
     )
   end
 
-  def self.create_created_pr!(week_in_review, statistic, user)
+  def self.create_created_pr!(week_in_review_id, statistic_id, user_id)
     pull_requests.created.create!(
-      week_in_review: week_in_review,
-      statistic: statistic,
-      user: user
+      week_in_review_id: week_in_review_id,
+      statistic_id: statistic_id,
+      user_id: user_id
     )
   end
 
-  def self.create_worked_pr!(week_in_review, statistic, user)
+  def self.create_worked_pr!(week_in_review_id, statistic_id, user_id)
     pull_requests.worked.create!(
-      week_in_review: week_in_review,
-      statistic: statistic,
-      user: user
+      week_in_review_id: week_in_review_id,
+      statistic_id: statistic_id,
+      user_id: user_id
     )
   end
 
-  def self.create_merged_pr!(week_in_review, statistic, user)
+  def self.create_merged_pr!(week_in_review_id, statistic_id, user_id)
     pull_requests.merged.create!(
-      week_in_review: week_in_review,
-      statistic: statistic,
-      user: user
+      week_in_review_id: week_in_review_id,
+      statistic_id: statistic_id,
+      user_id: user_id
     )
   end
 end

--- a/app/services/week_in_reviews/append.rb
+++ b/app/services/week_in_reviews/append.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+module WeekInReviews
+  class Append
+    attr_reader :statistic, :week_in_review, :user, :hub_id, :boundries, :start_time, :end_time
+
+    def initialize(statistic, week_in_review, user)
+      @statistic = statistic
+      @week_in_review = week_in_review
+      @user = user
+      @hub_id = GithubUser.find_by(user_id: user.id)&.github_id
+      @boundries = WeekInReviews::Boundries.new(week_in_review.start_date.to_s)
+      @start_time = boundries.start_time
+      @end_time = boundries.end_time
+    end
+
+    # Creates the correct Accomplishment records for the initialized Statistic,
+    # WeekInReview, and User.
+    #
+    # @return [Array<Accomplishmet>] An array of the newly created Accomplishments
+    #
+    def new_accomplishments!
+      case statistic.source_type
+      when Statistic::ISSUE
+        create_issue_accomplishments!
+      when Statistic::PR
+        create_pull_request_accomplishments!
+      end
+    end
+
+    private
+
+    def create_issue_accomplishments!
+      accomplishments = []
+      accomplishments << create('created_issue!') if user_created? && created_during_wir?
+      accomplishments << create('worked_issue!') if updated_during_wir?
+      accomplishments << create('closed_issue!') if closed_during_wir?
+      accomplishments
+    end
+
+    def create_pull_request_accomplishments!
+      accomplishments = []
+      accomplishments << create('created_pr!') if created_during_wir?
+      accomplishments << create('worked_pr!') if updated_during_wir?
+      accomplishments << create('merged_pr!') if closed_during_wir? && merged?
+      accomplishments
+    end
+
+    def create(accomplishment_method)
+      Accomplishment.send(
+        "create_#{accomplishment_method}",
+        week_in_review.id,
+        statistic.id,
+        user.id
+      )
+    end
+
+    def user_created?
+      statistic.source_created_by == hub_id
+    end
+
+    def created_during_wir?
+      return unless statistic.source_created_at >= start_time
+
+      statistic.source_created_at <= end_time
+    end
+
+    def updated_during_wir?
+      return unless statistic.source_updated_at >= start_time
+
+      statistic.source_updated_at <= end_time
+    end
+
+    def closed_during_wir?
+      return unless statistic.source_closed_at
+      return unless statistic.source_closed_at >= start_time
+
+      statistic.source_closed_at <= end_time
+    end
+
+    def merged?
+      statistic.state == Statistic::MERGED
+    end
+  end
+end

--- a/app/services/week_in_reviews/builder.rb
+++ b/app/services/week_in_reviews/builder.rb
@@ -57,7 +57,7 @@ module WeekInReviews
       statistics = filter.send(filter_method)
 
       statistics.each do |statistic|
-        Accomplishment.send(accomplishment_method, week_in_review, statistic, user)
+        Accomplishment.send(accomplishment_method, week_in_review.id, statistic.id, user.id)
       end
     end
   end

--- a/spec/services/week_in_reviews/append_spec.rb
+++ b/spec/services/week_in_reviews/append_spec.rb
@@ -1,0 +1,214 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe WeekInReviews::Append do
+  describe '.#new_accomplishments!' do
+    let(:dec_10th) { '2018-12-10' }
+    let(:dec_16th) { '2018-12-16' }
+    let(:during_week_in_review) { '2018-12-12T10:31:41Z' }
+    let(:before_week_in_review) { '2018-10-12T10:31:41Z' }
+    let(:user) { create :user }
+    let(:github_user) { create :github_user, user_id: user.id }
+    let(:week_in_review) do
+      create(
+        :week_in_review,
+        user: user,
+        start_date: dec_10th,
+        end_date: dec_16th
+      )
+    end
+
+    it 'returns an array of the created Accomplishment records', :aggregate_failures do
+      statistic = create(
+        :statistic,
+        :closed_issue,
+        source_created_at: before_week_in_review,
+        source_updated_at: during_week_in_review,
+        source_closed_at: during_week_in_review
+      )
+
+      results = WeekInReviews::Append.new(statistic, week_in_review, user).new_accomplishments!
+
+      expect(results.class).to eq Array
+      expect(results.map(&:class).uniq).to eq [Accomplishment]
+    end
+
+    context 'when the initialized Statistic is an issue' do
+      context 'and it was created (by someone else), updated and closed during the WeekInReview in question' do
+        let(:statistic) do
+          create(
+            :statistic,
+            :closed_issue,
+            source_created_at: during_week_in_review,
+            source_updated_at: during_week_in_review,
+            source_closed_at: during_week_in_review
+          )
+        end
+
+        it 'should create an issue worked and issue closed Accomplishments', :aggregate_failures do
+          expect(user.accomplishments.count).to eq 0
+
+          WeekInReviews::Append.new(statistic, week_in_review, user).new_accomplishments!
+
+          expect(user.accomplishments.count).to eq 2
+          expect(user.accomplishments.pluck(:type).uniq).to eq [Statistic::ISSUE]
+          expect(user.accomplishments.pluck(:action)).to include 'worked', 'closed'
+          expect(user.accomplishments.pluck(:user_id).uniq).to eq [user.id]
+          expect(user.accomplishments.pluck(:statistic_id).uniq).to eq [statistic.id]
+          expect(user.accomplishments.pluck(:week_in_review_id).uniq).to eq [week_in_review.id]
+        end
+      end
+
+      context 'and it was created by the user, and updated during the WeekInReview in question' do
+        let(:statistic) do
+          create(
+            :statistic,
+            :open_issue,
+            source_created_by: github_user.github_id,
+            source_created_at: during_week_in_review,
+            source_updated_at: during_week_in_review
+          )
+        end
+
+        it 'should create an issue created and issue worked Accomplishments', :aggregate_failures do
+          expect(user.accomplishments.count).to eq 0
+
+          WeekInReviews::Append.new(statistic, week_in_review, user).new_accomplishments!
+
+          expect(user.accomplishments.count).to eq 2
+          expect(user.accomplishments.pluck(:type).uniq).to eq [Statistic::ISSUE]
+          expect(user.accomplishments.pluck(:action)).to include 'worked', 'created'
+          expect(user.accomplishments.pluck(:user_id).uniq).to eq [user.id]
+          expect(user.accomplishments.pluck(:statistic_id).uniq).to eq [statistic.id]
+          expect(user.accomplishments.pluck(:week_in_review_id).uniq).to eq [week_in_review.id]
+        end
+      end
+
+      context 'and it was updated during the WeekInReview in question' do
+        let(:statistic) do
+          create(
+            :statistic,
+            :open_issue,
+            source_created_at: during_week_in_review,
+            source_updated_at: during_week_in_review
+          )
+        end
+
+        it 'should create an issue worked Accomplishments', :aggregate_failures do
+          expect(user.accomplishments.count).to eq 0
+
+          WeekInReviews::Append.new(statistic, week_in_review, user).new_accomplishments!
+
+          expect(user.accomplishments.count).to eq 1
+          expect(user.accomplishments.pluck(:type).uniq).to eq [Statistic::ISSUE]
+          expect(user.accomplishments.pluck(:action)).to include 'worked'
+          expect(user.accomplishments.pluck(:user_id).uniq).to eq [user.id]
+          expect(user.accomplishments.pluck(:statistic_id).uniq).to eq [statistic.id]
+          expect(user.accomplishments.pluck(:week_in_review_id).uniq).to eq [week_in_review.id]
+        end
+      end
+    end
+
+    context 'when the initialized Statistic is a pull request' do
+      context 'and it was updated and merged during the WeekInReview in question' do
+        let(:statistic) do
+          create(
+            :statistic,
+            :merged_pr,
+            source_created_at: before_week_in_review,
+            source_updated_at: during_week_in_review,
+            source_closed_at: during_week_in_review
+          )
+        end
+
+        it 'should create a PR worked and PR merged Accomplishments', :aggregate_failures do
+          expect(user.accomplishments.count).to eq 0
+
+          WeekInReviews::Append.new(statistic, week_in_review, user).new_accomplishments!
+
+          expect(user.accomplishments.count).to eq 2
+          expect(user.accomplishments.pluck(:type).uniq).to eq [Statistic::PR]
+          expect(user.accomplishments.pluck(:action)).to include 'worked', 'merged'
+          expect(user.accomplishments.pluck(:user_id).uniq).to eq [user.id]
+          expect(user.accomplishments.pluck(:statistic_id).uniq).to eq [statistic.id]
+          expect(user.accomplishments.pluck(:week_in_review_id).uniq).to eq [week_in_review.id]
+        end
+      end
+
+      context 'and it was created and updated during the WeekInReview in question' do
+        let(:statistic) do
+          create(
+            :statistic,
+            :open_pr,
+            source_created_at: during_week_in_review,
+            source_updated_at: during_week_in_review
+          )
+        end
+
+        it 'should create a PR worked and PR merged Accomplishments', :aggregate_failures do
+          expect(user.accomplishments.count).to eq 0
+
+          WeekInReviews::Append.new(statistic, week_in_review, user).new_accomplishments!
+
+          expect(user.accomplishments.count).to eq 2
+          expect(user.accomplishments.pluck(:type).uniq).to eq [Statistic::PR]
+          expect(user.accomplishments.pluck(:action)).to include 'worked', 'created'
+          expect(user.accomplishments.pluck(:user_id).uniq).to eq [user.id]
+          expect(user.accomplishments.pluck(:statistic_id).uniq).to eq [statistic.id]
+          expect(user.accomplishments.pluck(:week_in_review_id).uniq).to eq [week_in_review.id]
+        end
+      end
+
+      context 'and it was created and closed during the WeekInReview in question' do
+        let(:statistic) do
+          create(
+            :statistic,
+            :closed_pr,
+            source_created_at: during_week_in_review,
+            source_updated_at: during_week_in_review,
+            source_closed_at: during_week_in_review
+          )
+        end
+
+        it 'should create a PR created and PR worked Accomplishments', :aggregate_failures do
+          expect(user.accomplishments.count).to eq 0
+
+          WeekInReviews::Append.new(statistic, week_in_review, user).new_accomplishments!
+
+          expect(user.accomplishments.count).to eq 2
+          expect(user.accomplishments.pluck(:type).uniq).to eq [Statistic::PR]
+          expect(user.accomplishments.pluck(:action)).to include 'worked', 'created'
+          expect(user.accomplishments.pluck(:user_id).uniq).to eq [user.id]
+          expect(user.accomplishments.pluck(:statistic_id).uniq).to eq [statistic.id]
+          expect(user.accomplishments.pluck(:week_in_review_id).uniq).to eq [week_in_review.id]
+        end
+      end
+
+      context 'and it was created, worked and merged during the WeekInReview in question' do
+        let(:statistic) do
+          create(
+            :statistic,
+            :merged_pr,
+            source_created_at: during_week_in_review,
+            source_updated_at: during_week_in_review,
+            source_closed_at: during_week_in_review
+          )
+        end
+
+        it 'should create a PR created, PR worked, and PR merged Accomplishments', :aggregate_failures do
+          expect(user.accomplishments.count).to eq 0
+
+          WeekInReviews::Append.new(statistic, week_in_review, user).new_accomplishments!
+
+          expect(user.accomplishments.count).to eq 3
+          expect(user.accomplishments.pluck(:type).uniq).to eq [Statistic::PR]
+          expect(user.accomplishments.pluck(:action)).to include 'worked', 'created', 'merged'
+          expect(user.accomplishments.pluck(:user_id).uniq).to eq [user.id]
+          expect(user.accomplishments.pluck(:statistic_id).uniq).to eq [statistic.id]
+          expect(user.accomplishments.pluck(:week_in_review_id).uniq).to eq [week_in_review.id]
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Background
There will be times when a user needs to manually add in an issue or pull request into their week in review, that is not showing up already.

Once we have it persisted to the db, we need to be able to create the appropriate `Accomplishment` records for it, linking it to the user's `WeekInReview`.  

## Issue Resolved
<!-- Keeping the format 'Issue #123' will automatically link & close the associated issue when this PR is merged -->
Issue #96 
 
## Definition of Done
 
- [x] Service class that takes in a `Statistic` record and creates the appropriate `Accomplishment` records for the associated `WeekInReview` record
- [x] Accounts for case where the user is not a creator or assignee of the `Statistic`
