### PR TITLE
Fix cloning

### DIFF
--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -298,7 +298,7 @@ type User {
   email: String!
   firstName: String!
   githubUser: GithubUser
-  githubUsername: String!
+  githubUsername: String
   id: Int!
   lastName: String!
   org: Organization

--- a/app/graphql/types/user_type.rb
+++ b/app/graphql/types/user_type.rb
@@ -9,7 +9,7 @@ module Types
     field :first_name, String, null: false
     field :last_name, String, null: false
     field :email, String, null: false
-    field :github_username, String, null: false
+    field :github_username, String, null: true
     field :created_at, String, null: false
     field :updated_at, String, null: false
     field :access_token, Boolean, null: true

--- a/bin/setup
+++ b/bin/setup
@@ -23,7 +23,7 @@ chdir APP_ROOT do
   system('bundle check') || system!('bundle install')
 
   # Install JavaScript dependencies if using Yarn
-  # system('bin/yarn')
+  system('bin/yarn')
 
   # puts "\n== Copying sample files =="
   # unless File.exist?('config/database.yml')

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,12 +1,14 @@
 OmniAuth.config.logger = Rails.logger
 
-Rails.application.config.middleware.use OmniAuth::Builder do
-  provider(
-    :google_oauth2,
-    Rails.application.credentials.google_auth[:client_id],
-    Rails.application.credentials.google_auth[:client_secret],
-    client_options: {
-      ssl: { ca_file: Rails.root.join('cacert.pem').to_s }
-    }
-  )
+if Rails.application&.credentials&.google_auth.present?
+  Rails.application.config.middleware.use OmniAuth::Builder do
+    provider(
+      :google_oauth2,
+      Rails.application.credentials.google_auth[:client_id],
+      Rails.application.credentials.google_auth[:client_secret],
+      client_options: {
+        ssl: { ca_file: Rails.root.join('cacert.pem').to_s }
+      }
+    )
+  end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -67,6 +67,13 @@ people = [
     email: 'susan@example.com',
     github_username: 'suzy',
     organization_id: etsy.id
+  },
+  {
+    first_name: 'Beth',
+    last_name: 'Potts',
+    email: 'beth@example.com',
+    github_username: 'bethpotts',
+    organization_id: dova.id
   }
 ]
 
@@ -75,7 +82,7 @@ people.each do |person|
 end
 
 john = User.find_by(github_username: 'jsmith')
-suzy = User.find_by(github_username: 'suzy')
+beth = User.find_by(github_username: 'bethpotts')
 
 
 #################  GithubUsers  ##################
@@ -91,6 +98,7 @@ gh_users = [
     oddball_employee: true
   },
   {
+    user_id: beth.id,
     github_login: 'bethpotts',
     avatar_url: 'https://avatars1.githubusercontent.com/u/14881910?v=4',
     api_url: 'https://api.github.com/users/bethpotts',
@@ -105,7 +113,7 @@ gh_users.each do |user|
 end
 
 smitty = GithubUser.find_by(github_login: 'jsmith')
-beth   = GithubUser.find_by(github_login: 'bethpotts')
+beth_gh_user = GithubUser.find_by(github_login: 'bethpotts')
 
 
 #################  Statistics  ##################
@@ -136,8 +144,8 @@ stats = [
     source_created_at: '2018-10-07T20:31:41Z',
     source_updated_at: '2018-10-09T20:31:42Z',
     source_closed_at: '2018-10-09T50:31:42Z',
-    source_created_by: beth.github_id,
-    assignees: [beth.github_id]
+    source_created_by: beth_gh_user.github_id,
+    assignees: [beth_gh_user.github_id]
   }
 ]
 
@@ -152,13 +160,13 @@ pr = Statistic.last
 #################  GithubUsersStatistics  ##################
 
 smitty.statistics << issue
-beth.statistics << pr
+beth_gh_user.statistics << pr
 
 
 #################  WeekInReviews & Accomplishments ##################
 
 date = pr.source_updated_at
-week_in_review = ::WeekInReviews::Builder.new(suzy, date).assemble!
+week_in_review = ::WeekInReviews::Builder.new(beth, date).assemble!
 
 
 #################  Comments  ##################
@@ -173,7 +181,7 @@ comments = [
 comments.each do |comment|
   Comment.create!(
     week_in_review_id: week_in_review.id,
-    user_id: suzy.id,
+    user_id: beth.id,
     body: comment[:body],
     type: comment[:type]
   )


### PR DESCRIPTION
## Background

Credentials are not available on initial clone. In order to access the credentials, you have to have the master key in place.  This will not be present when the repo is initially cloned.

Its absence was preventing the initial bin/setup to complete.

User must have a `GithubUser` to build a `WeekInReview`. Not having a user was causing the rake db:seed process to blow up.
 
## Definition of Done
 
- [x] Ensure initializers work on cloning
- [x] Ensure `rake db:seed` works on cloning
